### PR TITLE
Fix a small typo in the LXD documentation

### DIFF
--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -59,7 +59,7 @@ So let's import some current Ubuntu and Debian images:
 現時点の Ubuntu と Debian イメージをインポートしてみましょう:
 
     lxd-images import lxc ubuntu trusty amd64 --alias ubuntu
-    lxd-images import lxc debian wheezy amd64 --aiias debian
+    lxd-images import lxc debian wheezy amd64 --alias debian
 
 <!--
 That's going to take a little while as it downloads both images (total of about 150MB)  

--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -29,7 +29,7 @@ import LXC images into it.
 So let's import some current Ubuntu and Debian images:
 
     lxd-images import lxc ubuntu trusty amd64 --alias ubuntu
-    lxd-images import lxc debian wheezy amd64 --aiias debian
+    lxd-images import lxc debian wheezy amd64 --alias debian
 
 That's going to take a little while as it downloads both images (total of about 150MB)  
 and then repacks them to be compatible with LXD.


### PR DESCRIPTION
Presumably, "aiias" should be "alias".