### PR TITLE
lxc file command should specify container name

### DIFF
--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -58,11 +58,11 @@ Or just run a command directly:
 
 To pull a file from the container, use:
 
-    lxc file pull /etc/hosts .
+    lxc file pull first/etc/hosts .
 
 To push one, use:
 
-    lxc file push hosts /tmp
+    lxc file push hosts first/tmp
 
 To stop the container, simply do:
 


### PR DESCRIPTION
according to the documentation <source> in the case of pull and <target> in the case of push are <container name>/<path>

Signed-off-by: Guillaume Vincent <gvincent@oslab.fr>