### PR TITLE
lxd: Update Japanese docs for 'lxc file' command and updated PPAs

### DIFF
--- a/content/cgmanager/downloads.ja.md
+++ b/content/cgmanager/downloads.ja.md
@@ -11,13 +11,18 @@ If not, just install it using your package manager.
 この 2 つでは、CGManager は一般的には LXC の依存パッケージとしてインストールされるか、デフォルトでインストールされるでしょう。
 
 <!--
-For Ubuntu users, the official LXC PPAs also contain up to date versions of CGManager:
+For Ubuntu users, we have an official PPA for CGManager:
 -->
-Ubuntu ユーザは、公式の LXC の PPA が CGManager のデイリーバージョンも提供しています:
+Ubuntu ユーザは、CGManager の公式 PPA があります:
 
- * [stable](https://launchpad.net/~ubuntu-lxc/+archive/stable): LXC の現在の stable リリース のバックポート
- * [daily-stable](https://launchpad.net/~ubuntu-lxc/+archive/daily-stable): LXC の stable-1.0 ブランチのデイリービルド
- * [daily](https://launchpad.net/~ubuntu-lxc/+archive/daily): LXC の master ブランチのデイリービルド
+ * [cgmanager-stable](https://launchpad.net/~ubuntu-lxc/+archive/cgmanager-stable): 最新の stable リリース <!-- Latest stable release -->
+
+<!--
+And for those who want development snapshots:
+-->
+開発中のスナップショットが必要な場合はこちらです:
+
+ * [cgmanager-git-master](https://launchpad.net/~ubuntu-lxc/+archive/cgmanager-git-master): "master" ブランチ <!-- "master" branch -->
 
 # 現時点の開発バージョン
 

--- a/content/lxc/downloads.ja.md
+++ b/content/lxc/downloads.ja.md
@@ -24,11 +24,19 @@ Production 環境では、2019 年 4 月までの長期サポートの Stable �
 <!--
 For Ubuntu users, we have official PPAs for LXC:
 -->
-Ubuntu ユーザは、LXC のオフィシャルな PPA があります。
+Ubuntu ユーザは、LXC のオフィシャルな PPA があります:
 
- * [stable](https://launchpad.net/~ubuntu-lxc/+archive/stable): 現在の Stable リリースのバックポート<!-- Backports of the current stable release -->
- * [daily-stable](https://launchpad.net/~ubuntu-lxc/+archive/lxc-git-stable-1.0): stable-1.0 ブランチのデイリービルド <!-- Daily builds of the stable-1.0 branch -->
- * [daily](https://launchpad.net/~ubuntu-lxc/+archive/daily): master ブランチのデイリービルド <!-- Daily builds of the master branch -->
+ * [lxc-lts](https://launchpad.net/~ubuntu-lxc/+archive/lxc-lts): 最新の長期サポート版リリース <!-- Latest long term release -->
+ * [lxc-stable](https://launchpad.net/~ubuntu-lxc/+archive/lxc-stable): 最新の stable リリース <!-- Latest stable release -->
+
+<!--
+And for those who want development snapshots:
+-->
+開発中のスナップショットが必要な場合はこちらです:
+
+ * [lxc-git-master](https://launchpad.net/~ubuntu-lxc/+archive/lxc-git-master): "master" ブランチ <!-- "master" branch -->
+ * [lxc-git-stable-1.0](https://launchpad.net/~ubuntu-lxc/+archive/lxc-git-stable-1.0): "stable-1.0" ブランチ <!-- "stable-1.0" branch -->
+ * [lxc-git-stable-1.1](https://launchpad.net/~ubuntu-lxc/+archive/lxc-git-stable-1.1): "stable-1.1" ブランチ <!-- "stable-1.1" branch -->
 
 # 現時点の開発バージョン <!-- Current development version -->
 

--- a/content/lxcfs/downloads.ja.md
+++ b/content/lxcfs/downloads.ja.md
@@ -7,11 +7,18 @@ We expect it to be soon picked up by the other distributions who already ship cg
 現時点ではUbuntuの最新の開発リリースにのみlxcfsが含まれています。すでに現時点でcgmanagerパッケージをリリースしている他のディストリビューションでも今後リリースが行われるでしょう。
 
 <!--
-For Ubuntu users, the official LXC PPAs also contain up to date versions of lxcfs:
+For Ubuntu users, we have an official PPA for LXCFS:
 -->
-Ubuntuユーザは、公式のLXC PPAにも最新のlxcfsがあります:
+Ubuntuユーザは、LXCFS の公式 PPA があります:
 
- * [daily](https://launchpad.net/~ubuntu-lxc/+archive/daily): LXC master ブランチのデイリービルド <!-- Daily builds of the LXC master branch -->
+* [lxcfs-stable](https://launchpad.net/~ubuntu-lxc/+archive/lxcfs-stable): 最新の stable リリース <!-- Latest stable release -->
+
+<!--
+And for those who want development snapshots:
+-->
+開発中のスナップショットが必要な場合はこちらです:
+
+ * [lxcfs-git-master](https://launchpad.net/~ubuntu-lxc/+archive/lxcfs-git-master): "master" ブランチ <!-- "master" branch -->
 
 # 現時点の開発バージョン <!-- Current development version -->
 

--- a/content/lxd/downloads.ja.md
+++ b/content/lxd/downloads.ja.md
@@ -7,11 +7,18 @@ We expect it to be soon picked up by the other distributions who already ship re
 現時点では Ubuntu だけが lxd のパッケージを提供しています。lxd パッケージが存在する Ubuntu のバージョンは現在の開発リリースのみです。すでに現時点で LXC パッケージをリリースしている他のディストリビューションでも今後リリースが行われるでしょう。
 
 <!--
-For Ubuntu users, there's also a daily PPA for LXD:
+For Ubuntu users, we have an official PPA for LXD:
 -->
-Ubuntuユーザは、公式のLXC PPAにも最新の lxd があります:
+Ubuntuユーザは、LXD の公式 PPA があります:
 
- * [lxd-git-master](https://launchpad.net/~ubuntu-lxc/+archive/lxd-git-master): Daily builds of the LXD master branch
+ * [lxd-stable](https://launchpad.net/~ubuntu-lxc/+archive/lxd-stable): 最新の stable リリース <!-- Latest stable release -->
+
+<!--
+And for those who want development snapshots:
+-->
+開発中のスナップショットが必要な場合はこちらです:
+
+ * [lxd-git-master](https://launchpad.net/~ubuntu-lxc/+archive/lxd-git-master): "master" ブランチ <!-- "master" branch -->
 
 # 現時点の開発バージョン <!-- Current development version -->
 

--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -103,14 +103,14 @@ To pull a file from the container, use:
 -->
 コンテナからファイルを取得するには以下のようにします:
 
-    lxc file pull /etc/hosts .
+    lxc file pull first/etc/hosts .
 
 <!--
 To push one, use:
 -->
 コンテナへファイルを送るには以下のようにします:
 
-    lxc file push hosts /tmp
+    lxc file push hosts first/tmp
 
 <!--
 To stop the container, simply do:


### PR DESCRIPTION
Update for https://github.com/lxc/linuxcontainers.org/pull/47 and 28e6b8d

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>