### PR TITLE
Added the add to instruction sets

### DIFF
--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -138,7 +138,7 @@ To talk to a remote LXD, you can simply add it with:
 -->
 リモートの LXD と通信するには、以下のようにホストを追加します:
 
-    lxc remote host-a https://<ip address>:8443
+    lxc remote add host-a https://<ip address>:8443
 
 <!--
 And after that, use all the same command as above but prefixing the container  

--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -78,7 +78,7 @@ It defaults to talking to the local one using a local UNIX socket.
 
 To talk to a remote LXD, you can simply add it with:
 
-    lxc remote host-a https://<ip address>:8443
+    lxc remote add host-a https://<ip address>:8443
 
 And after that, use all the same command as above but prefixing the container  
 and images name with the remote host like:


### PR DESCRIPTION
Both Getting started guides were missing the add text for the lxc remote add command.