### PR TITLE
tell users to dist-upgrade too

### DIFF
--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -4,6 +4,7 @@ As LXD evolves quite rapidly, we recommend Ubuntu users use our PPA:
 
     add-apt-repository ppa:ubuntu-lxc/lxd-git-master
     apt-get update
+    apt-get dist-upgrade
     apt-get install lxd
 
 The package creates a new "lxd" group which contains all users allowed to talk to  


### PR DESCRIPTION
Due to the LXC ABI break, users need to dist-upgrade to get the PPA version
of lxc so that they don't get weird errors.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>