### PR TITLE
Push example should write into tmp

### DIFF
--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -174,7 +174,7 @@ To push one, use:
 -->
 コンテナへファイルを送るには以下のようにします:
 
-    lxc file push hosts first/tmp
+    lxc file push hosts first/tmp/
 
 <!--
 To stop the container, simply do:

--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -100,7 +100,7 @@ To pull a file from the container, use:
 
 To push one, use:
 
-    lxc file push hosts first/tmp
+    lxc file push hosts first/tmp/
 
 To stop the container, simply do:
 


### PR DESCRIPTION
The example previously tried to replace tmp instead of writing hosts
into tmp.

The error return was:

error exit status 255: mntns dir: /proc/24893/ns/mnt
open container: Is a directory