### PR TITLE
Add 'API clients' section to LXD API page

### DIFF
--- a/content/lxd/rest-api.md
+++ b/content/lxd/rest-api.md
@@ -13,3 +13,10 @@ Once an API is marked as "stable", as is the case with the 1.0 API. We commit no
 We will however make API additions which will be accompanied by an identifier which newer clients can look for.
 
 This means that newer clients can detect whether a given target server supports the new feature and only use it if it does.
+
+## API clients
+
+The following API clients have been submitted by third-party contributors.  They
+are neither supported nor endorsed by the LXD project.
+
+* Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)


### PR DESCRIPTION
@tych0 suggested I add a link to my new Ruby API client to the articles page.  I added it under an 'API clients' section, as it didn't seem to fit in any of the other categories.