### PR TITLE
Translate the part of the new features of LXC 2.1 into Japanese

### DIFF
--- a/content/lxc/news.md
+++ b/content/lxc/news.md
@@ -178,7 +178,7 @@ will be considered by LXC. This is in line with prior LXC version. For example:
     lxc.net.2.link = br0
     lxc.net.2.link = virbr0
 
-Wwould lead to LXC associating the network with `virbr0` since it is the last key in the configuration.
+would lead to LXC associating the network with `virbr0` since it is the last key in the configuration.
 
 ### Table of changed configuration keys
 The following table lists the legacy configuration keys on the left side and their corresponding new keys on the right side. Keys that have been entirely removed will have "-" as entry in the "New Key" column and a comment saying "removed" in the "Comments" table.


### PR DESCRIPTION
I guess that many Japanese lxc users want to know
about new features of LXC 2.1 as soon as possible,
so I have not finished all the translations of LXC 2.1
announcement yet, but I publish it.

I am going to translate the rest as soon as possible.

This patch also fixes a typo in English announcement.

Reviewed-by: Hiroaki Nakamura <hnakamur@gmail.com>
Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>