### PR TITLE
Add Haskell LXD client

### DIFF
--- a/content/lxd/rest-api.ja.md
+++ b/content/lxd/rest-api.ja.md
@@ -47,3 +47,4 @@ are neither supported nor endorsed by the LXD project.
 * Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)
 * Node.js: [node-lxd](http://github.com/alandoherty/node-lxd)
 * Java: [jlxd](http://github.com/digitalspider/jlxd)
+* Haskell: [lxd-client](https://hackage.haskell.org/package/lxd-client)

--- a/content/lxd/rest-api.md
+++ b/content/lxd/rest-api.md
@@ -27,3 +27,4 @@ are neither supported nor endorsed by the LXD project.
 * Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)
 * Node.js: [node-lxd](http://github.com/alandoherty/node-lxd)
 * Java: [jlxd](http://github.com/digitalspider/jlxd)
+* Haskell: [lxd-client](https://hackage.haskell.org/package/lxd-client)

--- a/content/lxd/rest-api.ru.md
+++ b/content/lxd/rest-api.ru.md
@@ -26,3 +26,4 @@
 
 * Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)
 * Node.js: [node-lxd](http://github.com/alandoherty/node-lxd)
+* Haskell: [lxd-client](https://hackage.haskell.org/package/lxd-client)


### PR DESCRIPTION
Add a link to LXD's REST API home page pointing to the Haskell LXD client library [lxd-client](https://hackage.haskell.org/package/lxd-client).