### PR TITLE
Wrapped news date onto its own line

### DIFF
--- a/generate
+++ b/generate
@@ -380,9 +380,9 @@ def gen_page(entry, override, prefix, **variables):
             if "origin" in article:
                 title = "<a href=\"%s\">%s</a>" % (article["origin"], title)
 
-            content += "\n\n\n## %s <span class=\"text-muted\">%s</span>\n" % \
+            content += "\n\n\n## %s \n<span class=\"text-muted\">%s</span>\n" % \
                 (title, date.strftime("%%-d%s of %%B %%Y" % suffix))
-
+            
             content += article["content"]
 
         with open("/tmp/test.md", "w+") as fd:

--- a/generate
+++ b/generate
@@ -382,7 +382,7 @@ def gen_page(entry, override, prefix, **variables):
 
             content += "\n\n\n## %s \n<span class=\"text-muted\">%s</span>\n" % \
                 (title, date.strftime("%%-d%s of %%B %%Y" % suffix))
-            
+
             content += article["content"]
 
         with open("/tmp/test.md", "w+") as fd:


### PR DESCRIPTION
Wrapped the news date onto its own line so it does not wrap with the title. The normal font size was fine instead of using the small size.

Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1519