### PR TITLE
Fix typo in getting-started guide for lxc.idmap config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output/*
 manpages/*
 content/lxc/apidoc/*
 .vscode
+.idea

--- a/content/lxc/getting-started.md
+++ b/content/lxc/getting-started.md
@@ -87,8 +87,8 @@ With that done, the last step is to create an LXC configuration file.
  * Create the ~/.config/lxc directory if it doesn't exist.
  * Copy /etc/lxc/default.conf to ~/.config/lxc/default.conf
  * Append the following two lines to it:
-    * lxc.id\_map = u 0 100000 65536
-    * lxc.id\_map = g 0 100000 65536
+    * lxc.idmap = u 0 100000 65536
+    * lxc.idmap = g 0 100000 65536
 
 Those values should match those found in /etc/subuid and /etc/subgid, the values above are those expected
 for the first user on a standard Ubuntu system.


### PR DESCRIPTION
additionally added `.idea` to `.gitignore`

Signed-off-by: Simon Bäumer baeumer@pm.me