### PR TITLE
Fix typo of lxc.idmap in Japanese and Korean page

### DIFF
--- a/content/lxc/getting-started.ja.md
+++ b/content/lxc/getting-started.ja.md
@@ -175,14 +175,14 @@ With that done, the last step is to create an LXC configuration file.
  * Create the ~/.config/lxc directory if it doesn't exist.
  * Copy /etc/lxc/default.conf to ~/.config/lxc/default.conf
  * Append the following two lines to it:
-    * lxc.id\_map = u 0 100000 65536
-    * lxc.id\_map = g 0 100000 65536
+    * lxc.idmap = u 0 100000 65536
+    * lxc.idmap = g 0 100000 65536
  -->
  * ~/.config/lxc ディレクトリがない場合は作成します。
  * /etc/lxc/default.conf を ~/.config/lxc/default.conf にコピーします。
  * 以下の 2 行をコピーしたファイルに追加します。
-    * lxc.id\_map = u 0 100000 65536
-    * lxc.id\_map = g 0 100000 65536
+    * lxc.idmap = u 0 100000 65536
+    * lxc.idmap = g 0 100000 65536
 
 <!--
 Those values should match those found in /etc/subuid and /etc/subgid, the values above are those expected

--- a/content/lxc/getting-started.ko.md
+++ b/content/lxc/getting-started.ko.md
@@ -71,8 +71,8 @@ lxc-attach 사용을 위한 추가 사양 :
  *  ~/.config/lxc 디렉토리가 없다면 생성해 줍니다.
  * /etc/lxc/default.conf를 ~/.config/lxc/default.conf로 복사합니다.
  * 복사한 파일에 아래 두 줄을 추가합니다.:
-    * lxc.id\_map = u 0 100000 65536
-    * lxc.id\_map = g 0 100000 65536
+    * lxc.idmap = u 0 100000 65536
+    * lxc.idmap = g 0 100000 65536
 
 위 값들은 /etc/subuid and /etc/subgid에 있는 것과 동일하여야 합니다. 현재 우분투에서 첫번째 사용자인 경우라면 위와 같은 값을 가지고 있을 것입니다.
 


### PR DESCRIPTION
Update for commit 3367dcb

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>