### PR TITLE
Link to the translation as a menu of LXD "documentaion" in Japanese page

### DIFF
--- a/content/STRUCTURE.ja.json
+++ b/content/STRUCTURE.ja.json
@@ -107,6 +107,11 @@
      "generator": "markdown",
      "meta": {"input": "lxd/getting-started-openstack.ja.md"}},
 
+     {"path": "/lxd/documentation",
+     "menu": ["LXD", "ドキュメント"],
+     "generator": "link",
+     "meta": {"url": "https://lxd-ja.readthedocs.io/ja/latest/"}},
+
     {"path": "/lxd/rest-api/",
      "title": "LXD - REST API",
      "menu": ["LXD", "REST API"],


### PR DESCRIPTION
We have translated LXD documentaion into Japanese.
It release at https://lxd-ja.readthedocs.io/ja/latest/.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>