### PR TITLE
Add ts-lxd to list of client libraries

### DIFF
--- a/content/lxd/rest-api.ja.md
+++ b/content/lxd/rest-api.ja.md
@@ -45,6 +45,8 @@ are neither supported nor endorsed by the LXD project.
 以下の API クライアントはサードパーティのコントリビュータが提供しているものです。これらは LXD プロジェクトがサポートしているわけでも、承認しているわけでもありません。
 
 * Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)
-* Node.js: [node-lxd](http://github.com/alandoherty/node-lxd)
+* Node.js:
+  * [ts-lxd](http://github.com/trufflesuite/ts-lxd)
+  * [node-lxd](http://github.com/alandoherty/node-lxd)
 * Java: [jlxd](http://github.com/digitalspider/jlxd)
 * Haskell: [lxd-client](https://hackage.haskell.org/package/lxd-client)

--- a/content/lxd/rest-api.md
+++ b/content/lxd/rest-api.md
@@ -25,6 +25,8 @@ The following API clients have been submitted by third-party contributors.  They
 are neither supported nor endorsed by the LXD project.
 
 * Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)
-* Node.js: [node-lxd](http://github.com/alandoherty/node-lxd)
+* Node.js:
+  * [ts-lxd](http://github.com/trufflesuite/ts-lxd)
+  * [node-lxd](http://github.com/alandoherty/node-lxd)
 * Java: [jlxd](http://github.com/digitalspider/jlxd)
 * Haskell: [lxd-client](https://hackage.haskell.org/package/lxd-client)

--- a/content/lxd/rest-api.ru.md
+++ b/content/lxd/rest-api.ru.md
@@ -25,5 +25,7 @@
 никогда не поддерживались и не продвигались проектом LXD project.
 
 * Ruby: [Hyperkit](http://jeffshantz.github.io/hyperkit)
-* Node.js: [node-lxd](http://github.com/alandoherty/node-lxd)
+* Node.js:
+  * [ts-lxd](http://github.com/trufflesuite/ts-lxd)
+  * [node-lxd](http://github.com/alandoherty/node-lxd)
 * Haskell: [lxd-client](https://hackage.haskell.org/package/lxd-client)


### PR DESCRIPTION
Hi there,

I've just recently ported `node-lxd` over to TypeScript, and my team and I will be maintaining this as a separate fork going forward. I've opened this PR to add it to the docs page in hopes that it'll get some people using it!

Right now the library is roughly at feature parity with node-lxd. It also has a much more modern API definition (which is especially nice for people who like to work with `async`/`await` and promises instead of callbacks). Since it's written in TypeScript, it is self-documenting and offers strong type definitions out of the box. Over the coming weeks I'll be adding support for APIs missing from `node-lxd`, including images, networks, clusters, resources, and storage pools.

Per the DCO, this commit was signed off and I attest that I understand and agree to the DCO agreement.