### PR TITLE
Update ArchLinux instructions

### DIFF
--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -40,11 +40,6 @@ Alternatively, the snap package can also be used on ArchLinux (see below).
 -->
 もしくは、snap パッケージを ArchLinux 上で使うこともできます (後述)。
 
-<!--
-Note that in both cases, you will need to build and install the linux-userns kernel.
--->
-いずれの場合でも、linux-userns カーネルをビルドしてインストールする必要があります。
-
 ### Fedora
 <!--
 Instructions on how to use the COPR repository for LXD can be [found here](https://copr.fedorainfracloud.org/coprs/ganto/lxd/).

--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -22,8 +22,6 @@ Instructions on how to use the AUR package for LXD can be [found here](https://w
 
 Alternatively, the snap package can also be used on ArchLinux (see below).
 
-Note that in both cases, you will need to build and install the linux-userns kernel.
-
 ### Fedora
 Instructions on how to use the COPR repository for LXD can be [found here](https://copr.fedorainfracloud.org/coprs/ganto/lxd/).
 


### PR DESCRIPTION
Arch Linux now enables CONFIG_USER_NS.
Compiling a custom kernel is no longer required.