### PR TITLE
Python 3.3 is not supported with xenial anymore with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - 3.3
  - 3.4
 before_install:
  - sudo add-apt-repository ppa:ubuntu-lxc/daily -y


### PR DESCRIPTION
Python 3.3 can not be used anymore because travis-ci chose to remove support for it with their virtual machines with ubuntu 16.04.