### PR TITLE
Remove "Add --template-option argument to lxc-create" section

### DIFF
--- a/content/lxc/news/lxc-3.0.4.yaml
+++ b/content/lxc/news/lxc-3.0.4.yaml
@@ -11,9 +11,6 @@ content: |-
   ##### [Fix for runC CVE-2019-5763](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
   This release comes with  a fix for the privileged container breakout discovered earlier this year. As per our policy we don't consider privileged containers root safe and thus LXC as not received a CVE for this. However, we still provide a fix in this release. For more details see [this blog post](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container).
 
-  ##### Add `--template-option` argument to `lxc-create`
-  This allows users to pass template options to the template called by `lxc-create` explicitly instead of relying on the `--` mechanism.
-
   ##### Prefix veth interface names with caller's uid
   To make it easier for users to inspect veth devices LXC will now prefix the uid of the caller for the host veth device.
 


### PR DESCRIPTION
We do not have the option on LXC 3.0.4.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>