### PR TITLE
Fix distrobuilder current build instructions

### DIFF
--- a/content/distrobuilder/introduction.ja.md
+++ b/content/distrobuilder/introduction.ja.md
@@ -42,7 +42,7 @@ The current build can also be installed directly with:
 -->
 最新の状態のビルドを直接次のようにインストールできます:
 
-    go get -v -x github.com/lxc/distrobuilder
+    go get -v -x github.com/lxc/distrobuilder/distrobuilder
 
 # 開発言語、ライセンス、コントリビュート <!-- Language, licensing and contributions -->
 <!--

--- a/content/distrobuilder/introduction.md
+++ b/content/distrobuilder/introduction.md
@@ -20,7 +20,7 @@ Release tarballs can be found in the [Downloads](/distrobuilder/downloads) secti
 
 The current build can also be installed directly with:
 
-    go get -v -x github.com/lxc/distrobuilder
+    go get -v -x github.com/lxc/distrobuilder/distrobuilder
 
 # Language, licensing and contributions
 distrobuilder is written in Go, it's free software and is developed under the Apache 2 license.


### PR DESCRIPTION
Running the command given in the documentation does not work, this
commit fixes the documentation.

Current command gives the following output:

```
$ go get -v -x github.com/lxc/distrobuilder
can't load package: package github.com/lxc/distrobuilder: no Go files in /home/lsix/go/src/github.com/lxc/distrobuilder
```

Signed-off-by: Lancelot SIX <lsix@lancelotsix.com>