### PR TITLE
fixes a dead link in "Getting Started" -> "Access Control"

### DIFF
--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -114,7 +114,7 @@ or use the "newgrp lxd" command in the shell you're going to use to talk to LXD.
 **WARNING**: Anyone with access to the LXD socket can fully control LXD,
 which includes the ability to attach host devices and filesystems, this
 should therefore only be given to users who would be trusted with root
-access to the host. You can learn more about LXD security [here](/lxd/docs/master/security/).
+access to the host. You can learn more about LXD security [here](/lxd/docs/master/security).
 
 # Creating and using your first container
 Creating your first container is as simple as:


### PR DESCRIPTION
The "here" link in the last sentence of the "Getting started CLI" -> "Access Control" is currently
leading to a 404 page. This commit fixes the link.

Direct link to the chapter
https://linuxcontainers.org/lxd/getting-started-cli/#access-control

Signed-off-by: Andre Eckardt <aeckardt@outlook.com>