### PR TITLE
Changing "snap install lxc" to "snap install lxd" on two pages

### DIFF
--- a/content/lxc/getting-started.ja.md
+++ b/content/lxc/getting-started.ja.md
@@ -95,7 +95,7 @@ Ubuntu では、LXC をインストールするのは次のように簡単です
 	
 もしくは
 	
-	sudo snap install lxc
+	sudo snap install lxd
 
 <!--
 Your system will then have all the LXC commands available, all its templates

--- a/content/lxc/getting-started.md
+++ b/content/lxc/getting-started.md
@@ -47,7 +47,7 @@ On such an Ubuntu system, installing LXC is as simple as:
 
 or
 
-    sudo snap install lxc
+    sudo snap install lxd
 
 Your system will then have all the LXC commands available, all its templates
 as well as the python3 binding should you want to script LXC.


### PR DESCRIPTION
content/lxc/getting-started.ja.md and content/lxc/getting-started.md used `sudo snap install lxc` in the installation process.
However, there's no "lxc" snap. I believe that this was a typo. This PR changes those commands to use the "lxd" snap.