### PR TITLE
 Added a Table-of-Content to getting-started-cli.md

### DIFF
--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -1,3 +1,6 @@
+##### Contents
+
+[TOC]
 
 # Installation
 ## Choose your release

--- a/generate
+++ b/generate
@@ -158,7 +158,8 @@ def md2html(content):
 
     # Using toc extension to generate HTML anchors for paragraphs
     anchors = markdown.extensions.toc.TocExtension(
-        permalink=1)
+        permalink=1,
+        toc_depth="1-4")
 
     # adds tables
     tables = markdown.extensions.tables.TableExtension(


### PR DESCRIPTION
Signed-off-by: Tobias Gerold <tobias@g3ro.eu>

* Added TOC on top of getting-started-cli.md
* also a header `Contents`
* limited `toc_depth` to h4 (so the TOC is not overloaded)