### PR TITLE
Replace TOC & add FencedCode Extension

### DIFF
--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -1,6 +1,26 @@
-##### Contents
+## Contents
 
-[TOC]
+* [Installation](#installation)
+    * [Choose your release](#choose-your-release)
+    * [Getting the packages](#getting-the-packages)
+        * [Linux](#linux)
+            * [Alpine Linux](#alpine-linux)
+            * [Arch Linux](#arch-linux)
+            * [Fedora](#fedora)
+            * [Gentoo](#gentoo)
+            * [Ubuntu](#ubuntu)
+            * [Snap package (Arch Linux, Debian, Fedora, OpenSUSE and Ubuntu)](#snap-package-arch-linux-debian-fedora-opensuse-and-ubuntu)
+        * [MacOS builds](#macos-builds)
+        * [Windows builds](#windows-builds)
+        * [Installing from source](#installing-from-source)
+* [Initial configuration](#initial-configuration)
+    * [Access control](#access-control)
+* [Creating and using your first container](#creating-and-using-your-first-container)
+* [Container images](#container-images)
+    * [Using the built-in image remotes](#using-the-built-in-image-remotes)
+    * [Using a remote LXD as an image server](#using-a-remote-lxd-as-an-image-server)
+    * [Manually importing an image](#manually-importing-an-image)
+* [Multiple hosts](#multiple-hosts)
 
 ---
 

--- a/generate
+++ b/generate
@@ -27,6 +27,7 @@ import markdown.extensions.footnotes
 import markdown.extensions.admonition
 import markdown.extensions.wikilinks
 import markdown.extensions.attr_list
+import markdown.extensions.fenced_code
 import pygments.formatters
 import os
 import re
@@ -183,10 +184,13 @@ def md2html(content):
     attr_list = markdown.extensions.attr_list.AttrListExtension(
      )
 
+    fenced_code = markdown.extensions.fenced_code.FencedCodeExtension(
+     )
+
     return markdown.markdown(content, extensions=[codehilite, anchors,
                                                   tables, footnotes,
                                                   admonition, wikilinks,
-                                                  attr_list])
+                                                  attr_list, fenced_code])
 
 
 def download_sort_key(download_name):

--- a/generate
+++ b/generate
@@ -159,8 +159,7 @@ def md2html(content):
 
     # Using toc extension to generate HTML anchors for paragraphs
     anchors = markdown.extensions.toc.TocExtension(
-        permalink=1,
-        toc_depth="1-4")
+        permalink=1,)
 
     # adds tables
     tables = markdown.extensions.tables.TableExtension(


### PR DESCRIPTION
In these two commits, I:

* decided to replace the visible Table of Content with a manual created table.
The reason for this is a conflict of aims, on one hand I would like to have all headers indexed (just like you implemented it), on the other hand the visible TOCs would be far too long if they contain all headers. To avoid the second scenario I added the `toc_depth`-option, but that removes the indexing for headers that are not included in it.
I noticed that it is more beneficial to have all headers indexed (so we can link to them and we can use bigger header sizes), thus I removed toc_depth from `generate` and replaced the TOC in getting-started-cli.md with a manually created one.

* added the "Fenced Code" Markdown Extension (I "need" this for the Advanced Guide and I think it is useful in general).

I hope you (@stgraber) agree :slightly_smiling_face:.