### PR TITLE
changed fedora copr link to lxc4

### DIFF
--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -86,9 +86,9 @@ Alternatively, the snap package can also be used on Arch Linux ([see below](#sna
 
 #### Fedora
 <!--
-Instructions on how to use the COPR repository for LXD can be [found here](https://copr.fedorainfracloud.org/coprs/ganto/lxc3/).
+Instructions on how to use the COPR repository for LXD can be [found here](https://copr.fedorainfracloud.org/coprs/ganto/lxc4/).
 -->
-LXD の COPR リポジトリの使い方については [こちら](https://copr.fedorainfracloud.org/coprs/ganto/lxc3/) をご覧ください。
+LXD の COPR リポジトリの使い方については [こちら](https://copr.fedorainfracloud.org/coprs/ganto/lxc4/) をご覧ください。
 
 <!--
 Alternatively, the snap package can also be used on Fedora (see below).

--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -67,7 +67,7 @@ To install the feature branch of LXD, run:
 Alternatively, the snap package can also be used on Arch Linux ([see below](#snap-package-arch-linux-debian-fedora-opensuse-and-ubuntu)).
 
 #### Fedora
-Instructions on how to use the COPR repository for LXD can be [found here](https://copr.fedorainfracloud.org/coprs/ganto/lxc3/).
+Instructions on how to use the COPR repository for LXD can be [found here](https://copr.fedorainfracloud.org/coprs/ganto/lxc4/).
 
 Alternatively, the snap package can also be used on Fedora ([see below](#snap-package-arch-linux-debian-fedora-opensuse-and-ubuntu)).
 


### PR DESCRIPTION
Hi,
This changes the Fedora copr link from lxc v3 to v4.

Signed-off-by: Fred Uggla <fred.uggla@owlnical.net>