### PR TITLE
demo: move terminal to the bottom

### DIFF
--- a/content/lxd/try-it.html
+++ b/content/lxd/try-it.html
@@ -3,7 +3,10 @@
 <script src="/static/js/term.js" type="text/javascript"></script>
 <script src="/static/js/bootstrap-rating.min.js" type="text/javascript"></script>
 <script src="/static/js/tryit.js" type="text/javascript"></script>
-<div class="p-strip is-shallow">
+
+<link href="/static/css/tryit.css" rel="stylesheet"/>
+
+<div class="p-strip is-shallow" id="tryit-instructions">
   <div class="row">
     <div class="col-12">
       <noscript>
@@ -67,16 +70,6 @@
               <td><span class="minutes"></span> minutes, <span class="seconds"></span> seconds</td>
             </tr>
           </table>
-        </div>
-      </div>
-
-      <div class="p-notification" id="tryit_console_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">Terminal</h2>
-          <div style="padding-right: 1rem; overflow: auto; background-color: #000;">
-            <div id="tryit_console" style="background-color:black;"></div>
-          </div>
-          <button class="p-button" id="tryit_console_reconnect" type="button" style="display:none">Reconnect</button>
         </div>
       </div>
 
@@ -378,3 +371,21 @@ lxc image delete clean-ubuntu</pre>
     </div>
   </div>
 </div>
+
+<div class="row" id="tryit_console_row" style="display:none">
+  <div class="col-12">
+    <hr/>
+    <div class="p-notification" id="tryit_console_panel">
+      <div class="p-notification__response">
+        <h2 class="p-heading--four">Terminal</h2>
+        <div style="padding-right: 1rem; overflow: auto; background-color: #000;">
+          <div id="tryit_console" style="background-color:black;"></div>
+        </div>
+        <button class="p-button" id="tryit_console_reconnect" type="button" style="display:none">Reconnect</button>
+      </div>
+    </div>
+  </div>
+</div>
+  
+
+

--- a/static/css/tryit.css
+++ b/static/css/tryit.css
@@ -1,0 +1,22 @@
+div#tryit_console_row {
+    position: fixed;
+    bottom: 0;
+    z-index: 10;
+    min-width: 100%;
+    padding: 0;
+    background: #fff;
+}
+
+div#tryit-instructions {
+    padding-bottom: 380px;
+}
+
+div#tryit_console_panel {
+    max-width: 1122px; /* 1170px from local.css - 2x24px padding */
+    margin-right: auto;
+    margin-left: auto;
+}
+
+.p-notification__response {
+    width:100%;
+}

--- a/static/js/tryit.js
+++ b/static/js/tryit.js
@@ -231,8 +231,9 @@ $(document).ready(function() {
                 $('#tryit_status_panel').css("display", "none");
                 $('#tryit_start_panel').css("display", "none");
                 $('#tryit_info_panel').css("display", "inherit");
-                $('#tryit_console_panel').css("display", "inherit");
+                $('#tryit_console_row').css("display", "inherit");
                 $('#tryit_examples_panel').css("display", "inherit");
+                $('footer.p-footer').css("display", "none");
 
                 tryit_console = data.id;
                 window.history.pushState("", "", "?id="+tryit_console+"#introduction");
@@ -299,8 +300,9 @@ $(document).ready(function() {
             $('#tryit_status_panel').css("display", "none");
             $('#tryit_start_panel').css("display", "none");
             $('#tryit_info_panel').css("display", "inherit");
-            $('#tryit_console_panel').css("display", "inherit");
+            $('#tryit_console_row').css("display", "inherit");
             $('#tryit_examples_panel').css("display", "inherit");
+            $('footer.p-footer').css("display", "none");
 
             tryit_console = data.id;
             window.history.pushState("", "", "?id="+tryit_console);


### PR DESCRIPTION
Move the terminal to the bottom of the page and make it sticky.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>