### PR TITLE
demo: add a start button

### DIFF
--- a/content/lxd/try-it.html
+++ b/content/lxd/try-it.html
@@ -38,10 +38,16 @@
       <div class="p-notification--information" id="tryit_start_panel" style="display:none">
         <div class="p-notification__response">
           <h2 class="p-heading--four">Start</h2>
-          <button class="p-button" id="tryit_accept" type="button">
-            <i aria-hidden="true" class="p-icon--success"></i>
-            I have read and accept the terms of service above
-          </button>
+          <div>
+            <input type="checkbox" value="" id="accepted-terms" />
+            <label for="accepted-terms">
+             I have read and I accept the terms of service above
+            </label>
+            <div id="terms-not-accepted" style="display:none;padding-bottom:1em;">
+             Please confirm that you have read and that you accept the terms of service.
+            </div>
+            <button type="submit" id="tryit_accept" class="btn btn-primary">Start</button>
+          </div>
           <div id="tryit_progress" style="display:none;width:100%;text-align:center;">
             <p class="p-heading--four">Starting the container <i class="p-icon--spinner u-animation--spin"></i></p>
           </div>

--- a/static/js/tryit.js
+++ b/static/js/tryit.js
@@ -249,6 +249,14 @@ $(document).ready(function() {
     }
 
     $('#tryit_accept').click(function() {
+        if (!$('#accepted-terms').prop("checked")) {
+            $('#terms-not-accepted').css("display", "inherit");
+            return
+        }
+        else {
+            $('#terms-not-accepted').css("display", "none");
+        };
+
         $('#tryit_terms_panel').css("display", "none");
         $('#tryit_accept').css("display", "none");
         $('#tryit_progress').css("display", "inherit");


### PR DESCRIPTION
Replace the checkbox that serves as a button to start
the demo with an actual checkbox plus start button.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>