### PR TITLE
demo: hide the terms checkbox when starting

### DIFF
--- a/content/lxd/try-it.html
+++ b/content/lxd/try-it.html
@@ -38,7 +38,7 @@
       <div class="p-notification--information" id="tryit_start_panel" style="display:none">
         <div class="p-notification__response">
           <h2 class="p-heading--four">Start</h2>
-          <div>
+          <div id="tryit_accept_terms">
             <input type="checkbox" value="" id="accepted-terms" />
             <label for="accepted-terms">
              I have read and I accept the terms of service above

--- a/static/js/tryit.js
+++ b/static/js/tryit.js
@@ -257,6 +257,7 @@ $(document).ready(function() {
             $('#terms-not-accepted').css("display", "none");
         };
 
+        $('#tryit_accept_terms').css("display", "none");
         $('#tryit_terms_panel').css("display", "none");
         $('#tryit_accept').css("display", "none");
         $('#tryit_progress').css("display", "inherit");


### PR DESCRIPTION
When starting the container, there is no need to keep displaying
the checkbox for accepting the terms.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>