### PR TITLE
several updates to the start page

### DIFF
--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -6,106 +6,6 @@
      "meta": {"input": "index.html"}},
 
 
-
-    {"path": "/lxc/",
-     "generator": "alias",
-     "meta": {"target": "/lxc/introduction/"}},
-
-    {"path": "/lxc/introduction/",
-     "title": "LXC - Introduction",
-     "menu": ["LXC", "Introduction"],
-     "generator": "markdown",
-     "meta": {"input": "lxc/introduction.md"}},
-
-    {"path": "/lxc/news/",
-     "title": "LXC - News",
-     "menu": ["LXC", "News"],
-     "generator": "news",
-     "meta": {"dir": "/content/lxc/news/",
-              "input": "lxc/news.md"}},
-
-    {"path": "/lxc/getting-started/",
-     "title": "LXC - Getting started",
-     "menu": ["LXC", "Getting started"],
-     "generator": "markdown",
-     "meta": {"input": "lxc/getting-started.md"}},
-
-    {"path": "/lxc/documentation/",
-     "title": "LXC - Documentation",
-     "menu": ["LXC", "Documentation"],
-     "generator": "markdown",
-     "meta": {"input": "lxc/documentation.md"}},
-
-    {"path": "/lxc/apidoc/",
-     "generator": "directory",
-     "meta": {"input": "lxc/apidoc"}},
-
-    {"path": "/lxc/manpages/",
-     "title": "LXC - Manpages",
-     "menu": ["LXC", "Manpages"],
-     "generator": "manpages",
-     "meta": {"dir": "/manpages/lxc"}},
-
-    {"path": "/lxc/contribute/",
-     "title": "LXC - Contribute",
-     "menu": ["LXC", "Contribute"],
-     "generator": "markdown",
-     "meta": {"input": "lxc/contribute.md"}},
-
-    {"path": "/lxc/security/",
-     "title": "LXC - Security",
-     "menu": ["LXC", "Security"],
-     "generator": "markdown",
-     "meta": {"input": "lxc/security.md"}},
-
-    {"path": "/lxc/downloads/",
-     "title": "LXC - Downloads",
-     "menu": ["LXC", "Downloads"],
-     "generator": "downloads",
-     "meta": {"dir": "/downloads/lxc",
-              "input": "lxc/downloads.md"}},
-
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "External resources"]},
-
-    {"path": "/lxc/articles/",
-     "title": "LXC - Articles",
-     "menu": ["LXC", "Articles"],
-     "generator": "markdown",
-     "meta": {"input": "lxc/articles.md"}},
-
-    {"path": "/lxc/forum/",
-     "menu": ["LXC", "Forum"],
-     "generator": "link",
-     "meta": {"url": "https://discuss.linuxcontainers.org"}},
-
-    {"path": "/lxc/mailing-lists/",
-     "menu": ["LXC", "Mailing lists"],
-     "generator": "link",
-     "meta": {"url": "https://lists.linuxcontainers.org"}},
-
-    {"path": "/lxc/irc/",
-     "menu": ["LXC", "IRC"],
-     "generator": "link",
-     "meta": {"url": "https://kiwiirc.com/client/irc.libera.chat/#lxc"}},
-
-    {"path": "/lxc/github/",
-     "menu": ["LXC", "GitHub"],
-     "generator": "link",
-     "meta": {"url": "https://github.com/lxc/lxc"}},
-
-    {"path": "/lxc/jenkins-ci/",
-     "menu": ["LXC", "Jenkins CI"],
-     "generator": "link",
-     "meta": {"url": "https://jenkins.linuxcontainers.org/view/LXC/"}},
-
-    {"path": "/lxc/travis-ci/",
-     "menu": ["LXC", "Travis CI"],
-     "generator": "link",
-     "meta": {"url": "https://travis-ci.org/lxc/lxc"}},
-
-
-
     {"path": "/lxd/",
      "generator": "alias",
      "meta": {"target": "/lxd/introduction/"}},
@@ -211,6 +111,107 @@
      "menu": ["LXD", "Travis CI"],
      "generator": "link",
      "meta": {"url": "https://travis-ci.org/lxc/lxd"}},
+
+
+
+    {"path": "/lxc/",
+     "generator": "alias",
+     "meta": {"target": "/lxc/introduction/"}},
+
+    {"path": "/lxc/introduction/",
+     "title": "LXC - Introduction",
+     "menu": ["LXC", "Introduction"],
+     "generator": "markdown",
+     "meta": {"input": "lxc/introduction.md"}},
+
+    {"path": "/lxc/news/",
+     "title": "LXC - News",
+     "menu": ["LXC", "News"],
+     "generator": "news",
+     "meta": {"dir": "/content/lxc/news/",
+              "input": "lxc/news.md"}},
+
+    {"path": "/lxc/getting-started/",
+     "title": "LXC - Getting started",
+     "menu": ["LXC", "Getting started"],
+     "generator": "markdown",
+     "meta": {"input": "lxc/getting-started.md"}},
+
+    {"path": "/lxc/documentation/",
+     "title": "LXC - Documentation",
+     "menu": ["LXC", "Documentation"],
+     "generator": "markdown",
+     "meta": {"input": "lxc/documentation.md"}},
+
+    {"path": "/lxc/apidoc/",
+     "generator": "directory",
+     "meta": {"input": "lxc/apidoc"}},
+
+    {"path": "/lxc/manpages/",
+     "title": "LXC - Manpages",
+     "menu": ["LXC", "Manpages"],
+     "generator": "manpages",
+     "meta": {"dir": "/manpages/lxc"}},
+
+    {"path": "/lxc/contribute/",
+     "title": "LXC - Contribute",
+     "menu": ["LXC", "Contribute"],
+     "generator": "markdown",
+     "meta": {"input": "lxc/contribute.md"}},
+
+    {"path": "/lxc/security/",
+     "title": "LXC - Security",
+     "menu": ["LXC", "Security"],
+     "generator": "markdown",
+     "meta": {"input": "lxc/security.md"}},
+
+    {"path": "/lxc/downloads/",
+     "title": "LXC - Downloads",
+     "menu": ["LXC", "Downloads"],
+     "generator": "downloads",
+     "meta": {"dir": "/downloads/lxc",
+              "input": "lxc/downloads.md"}},
+
+    {"path": "/lxc/external-resources/",
+     "menu": ["LXC", "External resources"]},
+
+    {"path": "/lxc/articles/",
+     "title": "LXC - Articles",
+     "menu": ["LXC", "Articles"],
+     "generator": "markdown",
+     "meta": {"input": "lxc/articles.md"}},
+
+    {"path": "/lxc/forum/",
+     "menu": ["LXC", "Forum"],
+     "generator": "link",
+     "meta": {"url": "https://discuss.linuxcontainers.org"}},
+
+    {"path": "/lxc/mailing-lists/",
+     "menu": ["LXC", "Mailing lists"],
+     "generator": "link",
+     "meta": {"url": "https://lists.linuxcontainers.org"}},
+
+    {"path": "/lxc/irc/",
+     "menu": ["LXC", "IRC"],
+     "generator": "link",
+     "meta": {"url": "https://kiwiirc.com/client/irc.libera.chat/#lxc"}},
+
+    {"path": "/lxc/github/",
+     "menu": ["LXC", "GitHub"],
+     "generator": "link",
+     "meta": {"url": "https://github.com/lxc/lxc"}},
+
+    {"path": "/lxc/jenkins-ci/",
+     "menu": ["LXC", "Jenkins CI"],
+     "generator": "link",
+     "meta": {"url": "https://jenkins.linuxcontainers.org/view/LXC/"}},
+
+    {"path": "/lxc/travis-ci/",
+     "menu": ["LXC", "Travis CI"],
+     "generator": "link",
+     "meta": {"url": "https://travis-ci.org/lxc/lxc"}},
+
+
 
 
 

--- a/content/index.fr.html
+++ b/content/index.fr.html
@@ -26,10 +26,38 @@
 
 <div class="p-strip--light">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>Projets. Les choses intéressantes.</h2>
     </div>
   </div>
+
+  <div class="row">
+    <div class="p-card col-12">
+      <h3>LXD</h3>
+      <div class="row">
+        <div class="col-8">
+          <p>LXD est la nouvelle expérience LXC avec une seule commande
+            intuitive pour contrôler tous vos conteneurs. Les conteneurs
+            sont gérés par le réseau de façon complètement transparente
+            grâce à une interface REST. Il marche aussi à grande échelle,
+            s'intégrant avec OpenStack.</p>
+          
+          <p>LXD a été annoncé en début Novembre 2014 et est en
+            développement actif.</p>
+        </div>
+
+        <div class="col-4">    
+          <p>
+            <a class="p-button--positive" href="/lxd/try-it/" role="button">Try it online</a>
+          </p><p>
+           <a class="p-button" href="/fr/lxd/introduction/" role="button">Plus d'information</a>
+          </p>
+        </div>
+        
+      </div>
+    </div>
+  </div>
+  
   <div class="row u-equal-height">
     <div class="p-card col-4">
       <h3>LXC</h3>
@@ -44,17 +72,20 @@
     </div>
 
     <div class="p-card col-4">
-      <h3>LXD</h3>
-      <p>LXD est la nouvelle expérience LXC avec une seule commande
-        intuitive pour contrôler tous vos conteneurs. Les conteneurs
-        sont gérés par le réseau de façon complètement transparente
-        grâce à une interface REST. Il marche aussi à grande échelle,
-        s'intégrant avec OpenStack.</p>
+      <h3>LXCFS</h3>
+      <p>Système de fichier (FUSE) offrant deux fonctionnalités principales:
+        <ul>
+          <li>Remplacement pour cpuinfo, meminfo, stat et uptime.</li>
+          <li>Une vue compatible avec cgroupfs permettant les écritures non-privilégiées.</li>
+        </ul>
+      </p>
+      
+      <p>Son but est de contourner les limites des systèmes de
+        fichiers procfs, sysfs et cgroupfs par la mise à disposition
+        de fichiers correspondant à ce que l'utilisateur s'attend à
+        voir dans un conteneur complet (système).</p>
 
-      <p>LXD a été annoncé en début Novembre 2014 et est en
-        développement actif.</p>
-
-      <p><a class="p-button" href="/fr/lxd/introduction/" role="button">Plus d'information</a></p>
+      <p><a class="p-button" href="/fr/lxcfs/introduction/" role="button">Plus d'information </a></p>
     </div>
 
     <div class="p-card col-4">
@@ -72,23 +103,3 @@
     </div>
   </div>
 </div>
-
-<div class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h3>LXCFS</h3>
-      <p>Système de fichier (FUSE) offrant deux fonctionnalités principales:
-        <ul>
-          <li>Remplacement pour cpuinfo, meminfo, stat et uptime.</li>
-          <li>Une vue compatible avec cgroupfs permettant les écritures non-privilégiées.</li>
-        </ul>
-      </p>
-
-      <p>Son but est de contourner les limites des systèmes de
-        fichiers procfs, sysfs et cgroupfs par la mise à disposition
-        de fichiers correspondant à ce que l'utilisateur s'attend à
-        voir dans un conteneur complet (système).</p>
-
-      <p><a class="p-button" href="/fr/lxcfs/introduction/" role="button">Plus d'information </a></p>
-    </div>
-  </div>

--- a/content/index.html
+++ b/content/index.html
@@ -2,17 +2,18 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-8 suffix-1">
-      <h1>Infrastructure for container projects.</h1>
-      <p>linuxcontainers.org is the umbrella project behind LXC,
-        LXD and LXCFS.</p>
+      <h1>Infrastructure for Linux systems</h1>
+      <p>linuxcontainers.org is the umbrella project behind LXD,
+        LXC, LXCFS and distrobuilder.</p>
 
       <p>The goal is to offer a distro and vendor neutral environment
         for the development of Linux container technologies.</p>
 
-      <p>Our main focus is system containers. That is, containers which
-        offer an environment as close as possible as the one you'd get from a
-        VM but without the overhead that comes with running a separate
-        kernel and simulating all the hardware.</p>
+      <p>Our focus is providing containers and virtual machines that run
+        full Linux systems. While VMs supply a complete environment,
+        system containers offer an environment as close as possible to
+        the one you'd get from a VM, but without the overhead that comes
+        with running a separate kernel and simulating all the hardware.</p>
     </div>
     <div class="col-4">
       <img src="/static/img/containers.png" alt="" />
@@ -22,59 +23,77 @@
 
 <div class="p-strip--light">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>Active projects</h2>
     </div>
   </div>
+
+  <div class="row">
+    <div class="p-card col-12">
+      <h3>LXD</h3>
+      <div class="row">
+        <div class="col-8">
+          <p>LXD is a next generation system container and virtual machine
+            manager. It offers a unified user experience around full Linux
+            systems running inside containers or virtual machines.</p>
+          
+          <p>LXD is image based and provides images for a wide number of
+            Linux distributions. It provides flexibility and scalability
+            for various use cases, with support for different storage
+            backends and network types and the option to install on
+            hardware ranging from an individual laptop or cloud instance
+            to a full server rack.</p>
+          
+          <p>When using LXD, you can manage your instances (containers and VMs)
+            with a single command line tool, or over the network in a transparent way
+            through a REST API.</p>
+        </div>
+
+        <div class="col-4">    
+          <p>
+            <a class="p-button--positive" href="/lxd/try-it/" role="button">Try it online</a>
+          </p><p>
+            <a class="p-button" href="/lxd/introduction/" role="button">Learn more</a>
+          </p>
+        </div>
+        
+      </div>
+    </div>
+  </div>
+      
   <div class="row u-equal-height">
     <div class="p-card col-4">
       <h3>LXC</h3>
-      <p>LXC is the well known set of tools, templates,
-        library and language bindings. It's pretty low
-        level, very flexible and covers just about every
-        containment feature supported by the upstream
-        kernel.</p>
+      <p>LXC is a well-known Linux container runtime that consists of
+        tools, templates, and library and language bindings. It's pretty
+        low level, very flexible and covers just about every containment
+        feature supported by the upstream kernel.</p>
       <p>LXC is production ready with LTS releases coming with 5 years
-         of security and bugfix updates.</p>
+        of security and bugfix updates.</p>
+      <p>LXC should not be confused with the <code class="light">lxc</code>
+        CLI client tool provided by LXD.</p>
       <p><a class="p-button" href="/lxc/introduction/" role="button">Learn more</a></p>
     </div>
 
     <div class="p-card col-4">
-      <h3>LXD</h3>
-      <p>LXD is the new LXC experience. It offers a
-        completely fresh and intuitive user experience
-        with a single command line tool to manage your
-        containers. Containers can be managed over the
-        network in a transparent way through a REST API.
-        It also works with large scale deployments by
-        integrating with cloud platforms like OpenNebula.</p>
-
-      <p>
-        <a class="p-button--positive" href="/lxd/try-it/" role="button">Try it</a>
-        <a class="p-button" href="/lxd/introduction/" role="button">Learn more</a>
-      </p>
-    </div>
-
-    <div class="p-card col-4">
       <h3>LXCFS</h3>
-      <p>Userspace (FUSE) filesystem offering two main things:
+      <p>LXCFS is a userspace (FUSE) filesystem which offers:
         <ul>
           <li>Overlay files for cpuinfo, meminfo, stat and uptime.</li>
           <li>A cgroupfs compatible tree allowing unprivileged writes.</li>
         </ul>
       </p>
 
-      <p>It's designed to workaround the shortcomings of procfs, sysfs
-        and cgroupfs by exporting files which match what a system
+      <p>It's designed to work around the shortcomings of procfs, sysfs
+        and cgroupfs by exporting files that match what a system
         container user would expect.</p>
 
       <p><a class="p-button" href="/lxcfs/introduction/" role="button">Learn more</a></p>
     </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-8">
+ 
+    <div class="p-card col-4">
       <h3>distrobuilder</h3>
-      <p>Image building tool for LXC/LXD:
+      <p>distrobuilder is an image building tool for LXC/LXD which offers:
         <ul>
           <li>Complex image definition as a simple YAML document.</li>
           <li>Multiple output formats (chroot, LXD, LXC).</li>
@@ -84,7 +103,7 @@
 
       <p>distrobuilder was created as a replacement for the old shell scripts
         that were shipped as part of LXC to generate images.
-        Its modern design uses pre-built official images whenever available,
+        Its modern design utilises pre-built official images whenever available,
         uses a declarative image definition (YAML) and supports a variety of
         modifications on the base image.</p>
 
@@ -115,7 +134,7 @@
 
       <p>It has now been deprecated in favor of the CGroup namespace
         in recent Linux kernels. On older kernels, LXCFS still offers
-        a cgroupfs emulation that can be used instead of cgmanager
+        a cgroupfs emulation that can be used instead of CGManager
         and is more widely compatible with existing userspace.</p>
 
       <p><a class="p-button" href="/cgmanager/introduction/" role="button">Learn more&nbsp;&rsaquo;</a></p>

--- a/content/index.ja.html
+++ b/content/index.ja.html
@@ -1,7 +1,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-8 suffix-1">
-      <h1>Infrastructure for container projects.</h1>
+      <h1>Infrastructure for Linux systems</h1>
       <p>
       <!--
         linuxcontainers.org is the umbrella project behind LXC,
@@ -35,10 +35,42 @@
 
 <div class="p-strip--light">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>活動中のプロジェクト <!-- Active projects --></h2>
     </div>
   </div>
+
+  <div class="row">
+    <div class="p-card col-12">
+      <h3>LXD</h3>
+      <div class="row">
+        <div class="col-8">
+          <p>
+            <!--
+                LXD is the new LXC experience. It offers a
+                completely fresh and intuitive user experience
+                with a single command line tool to manage your
+                containers. Containers can be managed over the
+                network in a transparent way through a REST API.
+                It also works with large scale deployments by
+                integrating with OpenStack.
+              -->
+            LXD は LXC の新しい体験です。コンテナを管理するための一つのコマンドラインツールで、完全に新鮮で直感的なユーザ体験を提供します。コンテナを REST API を通した透過的な方法でネットワーク経由で管理できます。LXD は OpenStack や OpenNebula との統合により大規模のデプロイも扱います。
+          </p>
+        </div>
+
+        <div class="col-4">    
+          <p>
+            <a class="p-button--positive" href="/ja/lxd/try-it/" role="button">試してみる</a>
+          </p><p>
+            <a class="p-button" href="/ja/lxd/introduction/" role="button">詳しく見る</a>
+          </p>
+        </div>
+        
+      </div>
+    </div>
+  </div>
+  
   <div class="row u-equal-height">
     <div class="p-card col-4">
       <h3>LXC</h3>
@@ -60,27 +92,6 @@
         LXC は production ready であり、LTS リリースが 5 年間のセキュリティアップデートとバグ修正を提供します。
       </p>
       <p><a class="p-button" href="/ja/lxc/introduction/" role="button">詳しく見る</a></p>
-    </div>
-
-    <div class="p-card col-4">
-      <h3>LXD</h3>
-      <p>
-        <!--
-          LXD is the new LXC experience. It offers a
-          completely fresh and intuitive user experience
-          with a single command line tool to manage your
-          containers. Containers can be managed over the
-          network in a transparent way through a REST API.
-          It also works with large scale deployments by
-          integrating with OpenStack.
-        -->
-        LXD は LXC の新しい体験です。コンテナを管理するための一つのコマンドラインツールで、完全に新鮮で直感的なユーザ体験を提供します。コンテナを REST API を通した透過的な方法でネットワーク経由で管理できます。LXD は OpenStack や OpenNebula との統合により大規模のデプロイも扱います。
-      </p>
-
-      <p>
-        <a class="p-button--positive" href="/ja/lxd/try-it/" role="button">試してみる</a>
-        <a class="p-button" href="/ja/lxd/introduction/" role="button">詳しく見る</a>
-      </p>
     </div>
 
     <div class="p-card col-4">
@@ -117,9 +128,8 @@
 
       <p><a class="p-button" href="/ja/lxcfs/introduction/" role="button">詳しく見る</a></p>
     </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-8">
+    
+    <div class="p-card col-4">
       <h3>distrobuilder</h3>
       <p>LXC/LXD 用のイメージ作成ツールです: <!-- Image building tool for LXC/LXD: -->
         <ul>
@@ -150,6 +160,11 @@
   <div class="row">
     <div class="col-8">
       <h2>廃止予定のプロジェクト <!-- Deprecated projects --></h2>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="p-card col-8">
       <h3>CGManager</h3>
       <p>
         <!--

--- a/content/index.ko.html
+++ b/content/index.ko.html
@@ -23,10 +23,38 @@
 
 <div class="p-strip--light">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>진행 중인 프로젝트들</h2>
     </div>
   </div>
+
+   <div class="row">
+     <div class="p-card col-12">
+       <h3>LXD</h3>
+       <div class="row">
+         <div class="col-8">
+           <p>LXD는 새로운 LXC 사용 환경입니다.
+             컨테이너 관리를 위해 단 하나의 명령어 도구를 사용하며,
+             이를 통해 완전히 새롭고 직관적인 사용자 경험을 제공합니다.
+             컨테이너는 네트워크 위에서 REST API를 통해 투명한 방법으로 관리될 수
+             있습니다. 오픈스택과 함께 통합되어, 매우 큰 규모의 배포시스템에서도
+             동작 가능합니다.</p>
+           
+           <p>LXD는 2014년 11월 초에 발표되었습니다. 그리고 현재까지도 활발하게 개발이 이루어지고 있습니다.</p>
+         </div>
+         
+         <div class="col-4">    
+           <p>
+             <a class="p-button--positive" href="/ko/lxd/try-it/" role="button">체험해 보기 </a>
+           </p><p>
+             <a class="p-button" href="/ko/lxd/introduction/" role="button">더 알아보기 </a>
+           </p>
+         </div>
+         
+       </div>
+     </div>
+   </div>
+  
   <div class="row u-equal-height">
     <div class="p-card col-4">
       <h3>LXC</h3>
@@ -36,23 +64,6 @@
         기능 들을 다루고 있습니다.</p>
         <p>production ready를 위해, LXC 1.0는 향후 5년동안 보안업데이트와 버그 수정이 이루어집니다 (2019년 4월까지).</p>
         <p><a class="p-button" href="/ko/lxc/introduction/" role="button">더 알아보기 </a></p>
-    </div>
-
-    <div class="p-card col-4">
-      <h3>LXD</h3>
-      <p>LXD는 새로운 LXC 사용 환경입니다.
-        컨테이너 관리를 위해 단 하나의 명령어 도구를 사용하며,
-        이를 통해 완전히 새롭고 직관적인 사용자 경험을 제공합니다.
-        컨테이너는 네트워크 위에서 REST API를 통해 투명한 방법으로 관리될 수
-        있습니다. 오픈스택과 함께 통합되어, 매우 큰 규모의 배포시스템에서도
-        동작 가능합니다.</p>
-
-      <p>LXD는 2014년 11월 초에 발표되었습니다. 그리고 현재까지도 활발하게 개발이 이루어지고 있습니다.</p>
-
-      <p>
-        <a class="p-button" href="/ko/lxd/introduction/" role="button">더 알아보기 </a>
-        <a class="p-button" href="/ko/lxd/try-it/" role="button">체험해 보기 </a>
-      </p>
     </div>
 
     <div class="p-card col-4">
@@ -72,10 +83,15 @@
   </div>
 </div>
 
-<div class="p-strip">
+<div class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2>종료된 프로젝트들</span></h2>
+      <h2>종료된 프로젝트들</h2>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="p-card col-8">
       <h3>CGManager</h3>
       <p>CGManager는 우리의 컨트롤 그룹 관리자 데몬입니다.
         중첩된(nested) 비특권 컨테이너에게도 DBus API를 통해, 각자의

--- a/content/index.pt_br.html
+++ b/content/index.pt_br.html
@@ -20,10 +20,36 @@
 
   <div class="p-strip--light">
     <div class="row">
-      <div class="col-8">
+      <div class="col-12">
         <h2>Projetos Ativo</h2>
       </div>
     </div>
+
+    <div class="row">
+      <div class="p-card col-12">
+        <h3>LXD</h3>
+        <div class="row">
+          <div class="col-8">
+            <p>LXD é a nova experiência LXC. Oferece uma experiência
+              de usuário completamente nova e intuitiva com uma única
+              ferramenta de linha de comando para gerenciar seus contêineres.
+              Os recipientes podem ser gerenciados pela rede de forma
+              transparente através de uma API REST. Também funciona com
+              implantações em grande escala integrando-se ao OpenStack.</p>
+          </div>
+          
+          <div class="col-4">    
+            <p>
+              <a class="p-button--positive" href="/lxd/try-it/" role="button">Experimente</a>
+            </p><p>
+              <a class="p-button" href="/lxd/introduction/" role="button">Saber mais</a>
+            </p>
+          </div>
+          
+        </div>
+      </div>
+    </div>
+    
     <div class="row u-equal-height">
       <div class="p-card col-4">
         <h3>LXC</h3>
@@ -35,21 +61,6 @@
           obtendo 5 anos de atualizações de segurança
           e correções de erros (até abril de 2019).</p>
         <p><a class="p-button" href="/lxc/introduction/" role="button">Saber mais</a></p>
-      </div>
-
-      <div class="p-card col-4">
-        <h3>LXD</h3>
-        <p>LXD é a nova experiência LXC. Oferece uma experiência
-          de usuário completamente nova e intuitiva com uma única
-          ferramenta de linha de comando para gerenciar seus contêineres.
-          Os recipientes podem ser gerenciados pela rede de forma
-          transparente através de uma API REST. Também funciona com
-          implantações em grande escala integrando-se ao OpenStack.</p>
-
-        <p>
-          <a class="p-button--positive" href="/lxd/try-it/" role="button">Experimente</a>
-          <a class="p-button" href="/lxd/introduction/" role="button">Saber mais</a>
-        </p>
       </div>
 
       <div class="p-card col-4">
@@ -70,10 +81,15 @@
     </div>
   </div>
 
-  <div class="p-strip">
-    <div class="row">
-      <div class="col-8">
-        <h2>Deprecated projects</h2>
+<div class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Deprecated projects</h2>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="p-card col-8">
         <h3>CGManager</h3>
         <p>CGManager is our cgroup manager daemon. It's
           designed to allow nested unprivileged containers
@@ -91,6 +107,6 @@
           and is more widely compatible with existing userspace.</p>
 
         <p><a class="p-button" href="/cgmanager/introduction/" role="button">Saber mais&nbsp;&rsaquo;</a></p>
-      </div>
     </div>
   </div>
+</div>

--- a/content/index.ru.html
+++ b/content/index.ru.html
@@ -32,12 +32,49 @@
 
 <div class="p-strip--light">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       <h2>
         Проекты. Интересные факты.
       </h2>
     </div>
   </div>
+
+  <div class="row">
+    <div class="p-card col-12">
+      <h3>LXD</h3>
+      <div class="row">
+        <div class="col-8">
+           <p>
+             LXD это новый опыт LXC.
+             Предлагающий полностью свежую и интуитивно
+             понятную работу с помощью всего одного
+             инструмента: командной строки для управления своими контейнерами.
+             Контейнерами можно управлять прозрачным образом по сети
+             через API REST.
+             Технология так же работает с развертыванием масштабных сред
+             путем интеграции с OpenStack.
+           </p>
+
+           <p>
+             О LXD было объявлено в начале ноября 2014 года
+             и по сей день он находится в очень активном развитии.
+           </p>
+        </div>
+
+        <div class="col-4">    
+          <p>
+            <a class="p-button--positive" href="/lxd/try-it/" role="button">Try it online</a>
+          </p><p>
+            <a class="p-button" href="/lxd/introduction/" role="button">
+              Подробнее
+            </a>
+          </p>
+        </div>
+        
+      </div>
+    </div>
+  </div>
+  
   <div class="row u-equal-height">
     <div class="p-card col-4">
       <h3>LXC</h3>
@@ -60,30 +97,29 @@
     </div>
 
     <div class="p-card col-4">
-      <h3>LXD</h3>
+      <h3>LXCFS</h3>
       <p>
-        LXD это новый опыт LXC.
-        Предлагающий полностью свежую и интуитивно
-        понятную работу с помощью всего одного
-        инструмента: командной строки для управления своими контейнерами.
-        Контейнерами можно управлять прозрачным образом по сети
-        через API REST.
-        Технология так же работает с развертыванием масштабных сред
-        путем интеграции с OpenStack.
+        Пользовательское пространство (FUSE) файловая система предлагает двe основныe вещи:
+        <ul>
+          <li>Слой файлов для CPUInfo, MemInfo, stat и uptime.</li>
+          <li>Cgroupfs совместимое дерево предоставлящее возможность непривилегированной записи.</li>
+        </ul>
       </p>
-
+      
       <p>
-        О LXD было объявлено в начале ноября 2014 года
-        и по сей день он находится в очень активном развитии.
+        Предназначена для обхода недостатков PROCFS,
+        sysfs и cgroupfs при экспорте файлов,
+        соответствующие тeм,
+        которые пользователь системы контейнера ожидает.
       </p>
-
+      
       <p>
-        <a class="p-button" href="/lxd/introduction/" role="button">
+        <a class="p-button" href="/lxcfs/introduction/" role="button">
           Подробнее
         </a>
       </p>
     </div>
-
+   
     <div class="p-card col-4">
       <h3>CGManager</h3>
       <p>
@@ -102,34 +138,6 @@
 
       <p>
         <a class="p-button" href="/cgmanager/introduction/" role="button">
-          Подробнее
-        </a>
-      </p>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h3>LXCFS</h3>
-      <p>
-        Пользовательское пространство (FUSE) файловая система предлагает двe основныe вещи:
-        <ul>
-          <li>Слой файлов для CPUInfo, MemInfo, stat и uptime.</li>
-          <li>Cgroupfs совместимое дерево предоставлящее возможность непривилегированной записи.</li>
-        </ul>
-      </p>
-
-      <p>
-        Предназначена для обхода недостатков PROCFS,
-        sysfs и cgroupfs при экспорте файлов,
-        соответствующие тeм,
-        которые пользователь системы контейнера ожидает.
-      </p>
-
-      <p>
-        <a class="p-button" href="/lxcfs/introduction/" role="button">
           Подробнее
         </a>
       </p>

--- a/content/lxd/introduction.md
+++ b/content/lxd/introduction.md
@@ -1,8 +1,8 @@
 
 
 # What's LXD?
-LXD is a next generation system container manager.
-It offers a user experience similar to virtual machines but using Linux containers instead.
+LXD is a next generation system container and virtual machine manager.
+It offers a unified user experience around full Linux systems running inside containers or virtual machines.
 
 It's image based with pre-made images available for a [wide number of Linux distributions](https://images.linuxcontainers.org)
 and is built around a very powerful, yet pretty simple, REST API.

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -190,6 +190,7 @@ pre {
 .p-navigation__logo {
   font-size: 1.5rem;
   line-height: 3rem;
+  padding: 0.2rem;
 }
 
 .p-navigation__link {

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -315,3 +315,7 @@ pre {
 code {
   background-color: #a19d9d;
 }
+
+code.light {
+  background-color: #f7f7f7;
+}

--- a/templates/common/header.tpl.html
+++ b/templates/common/header.tpl.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          Linux containers
+         <img src="/static/img/containers.small.png" alt="Linux containers logo" border="0" />
         </a>
       </div>
       {% if menu %}


### PR DESCRIPTION
Some usability and content updates to the start page:

- Replace "Linux containers" link in the header with logo
- Switch order of LXD and LXC tabs in the header
- Switch the card order to have LXD as first card on a
  separate row, followed by the other projects
  (same change for other languages)
- update English text for all cards

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>