### PR TITLE
css: fix width of logo in the header

### DIFF
--- a/static/css/local.css
+++ b/static/css/local.css
@@ -193,6 +193,10 @@ pre {
   padding: 0.2rem;
 }
 
+.p-navigation__logo img {
+  width: 45px;
+}
+
 .p-navigation__link {
   position: relative;
 }


### PR DESCRIPTION
Some browsers make the link on the img wider than the actual
image, which results in the image being stretched or aligned
wrong.
Specifying the width (for only the image in the logo tag)
fixes this.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>