### PR TITLE
css: fix styling for code tag

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -70,7 +70,7 @@
         feature supported by the upstream kernel.</p>
       <p>LXC is production ready with LTS releases coming with 5 years
         of security and bugfix updates.</p>
-      <p>LXC should not be confused with the <code class="light">lxc</code>
+      <p>LXC should not be confused with the <code>lxc</code>
         CLI client tool provided by LXD.</p>
       <p><a class="p-button" href="/lxc/introduction/" role="button">Learn more</a></p>
     </div>

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -313,9 +313,10 @@ pre {
 }
 
 code {
-  background-color: #a19d9d;
+  background-color: #f7f7f7;
+  padding: 3px;
 }
 
-code.light {
-  background-color: #f7f7f7;
+h1 code, h2 code, h3 code, h4 code {
+  background-color: inherit;
 }


### PR DESCRIPTION
Use a lighter background color for the <code> tag to make
it look less obtrusive. This way we can also get rid of
the .light class.
Do not use a background color in headings. Monospace is
sufficient.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>