### PR TITLE
doc: css: fix word wrap in tables

### DIFF
--- a/content/lxd/docs/.template.html
+++ b/content/lxd/docs/.template.html
@@ -87,8 +87,10 @@
         display: block;
       }
 
-      .p-content table td {
-        white-space: nowrap;
+      @media only screen and (min-width:901px) and (max-width:1199px), (max-width:699px) {
+          .p-content table td {
+              white-space: nowrap;
+          }
       }
 
       .p-content h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Wrap text in table columns if there is enough space for it,
otherwise the table will be scrollable as before.
The current implementation will wrap if the width is >= 700px
in mobile view or >= 1200px in desktop view.
If the screen is smaller, text would wrap to one word per line,
which isn't readable.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>