### PR TITLE
add linkify for plain links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ Translations for other languages are possible and appreciated. See [Translations
    wikilinks
    attr_list
    fenced_code
+   mdx-linkify
    ```
 
    See also:

--- a/README.md
+++ b/README.md
@@ -31,21 +31,22 @@ Install the following software (naming may depends on your distribution):
  * python3-jinja2
  * python3-markdown (>= 3.3.4)
  * python3-pygments
+ * mdx-linkify
 
 ### Clone the repo
 
     git clone https://github.com/lxc/linuxcontainers.org
-  
-**Note:** The folder `downloads` is quite big, so you can skip that folder by using [git sparse-checkout & partial clones](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/#sparse-checkout-and-partial-clones) 
+
+**Note:** The folder `downloads` is quite big, so you can skip that folder by using [git sparse-checkout & partial clones](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/#sparse-checkout-and-partial-clones)
 (The only exception is, when you work on the downloads page).
 
 As a replacement for the missing `downloads` folder you need to create the following empty folders, before generating the website  (otherwise the generator shows an error):
 
 ```
 downloads/cgmanager/
-downloads/distrobuilder/  
-downloads/lxc/  
-downloads/lxcfs/  
+downloads/distrobuilder/
+downloads/lxc/
+downloads/lxcfs/
 downloads/lxd/
 ```
 
@@ -53,7 +54,7 @@ downloads/lxd/
 
     ./generate
 
-### Launching the website 
+### Launching the website
 
 After generating the website(above), run these commands(Ubuntu-specific):
 
@@ -64,7 +65,7 @@ Now you can access the website in your browser by using your local IP address an
 
     127.0.0.1:8777
 
-#### (Alternative) Launching within a container 
+#### (Alternative) Launching within a container
 
 **Inside the container:**
 
@@ -84,10 +85,3 @@ You can now navigate to the site (in a browser of your choice) with the containe
 ## Bug reports & Content requests
 
 Bug reports, requests and ideas regarding the website can be filed at https://github.com/lxc/linuxcontainers.org/issues/new
-
-
-
-
-
-
-

--- a/generate
+++ b/generate
@@ -29,6 +29,7 @@ import markdown.extensions.wikilinks
 import markdown.extensions.attr_list
 import markdown.extensions.def_list
 import markdown.extensions.fenced_code
+from mdx_linkify.mdx_linkify import LinkifyExtension
 import pygments.formatters
 import os
 import re
@@ -151,6 +152,14 @@ def gen_menu(structure, override, prefix):
     return menu
 
 
+def linkify_only_http(attrs, new=False):
+
+    if not attrs["_text"].startswith("http"):
+        return None
+
+    return attrs
+
+
 def md2html(content):
     """
         Given path to Markdown file, return rendered HTML content.
@@ -193,12 +202,15 @@ def md2html(content):
 
     include_toc = IncludeToCExtension()
 
+    mdx_linkify = LinkifyExtension(linker_options={
+        "callbacks": [linkify_only_http], "skip_tags": ['a']})
+
     return markdown.markdown(content, extensions=[codehilite, anchors,
                                                   tables, footnotes,
                                                   admonition, wikilinks,
                                                   attr_list, fenced_code,
                                                   'def_list', 'md_in_html',
-                                                  include_toc])
+                                                  include_toc, mdx_linkify])
 
 
 def download_sort_key(download_name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jinja2
 markdown>=3.3.4
 pygments
 pyyaml
+mdx-linkify


### PR DESCRIPTION
@stgraber This change needs the mdx-linkify pip package to be installed on the server.

Use mdx-linkify to discover URLs in plain text and add links
to them.
Restrict it to only add links for URLs starting with http or
https though - mdx-linkify tries to be very smart otherwise
and gives a lot of false positives.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>