### PR TITLE
css: prevent line breaks in code blocks

### DIFF
--- a/static/css/local.css
+++ b/static/css/local.css
@@ -134,6 +134,13 @@ p:empty {
 /* Add spacing to pre tags */
 pre {
   margin-top: .5rem;
+  overflow: auto;
+  max-height: 50rem;
+}
+
+/* prevent line breaks in code blocks */
+pre code {
+  white-space: pre;
 }
 
 .glyphicon {


### PR DESCRIPTION
Make sure that code blocks are displayed as pre-formatted
and add scroll bars as required.
Also restrict the height of code blocks so the scroll bars
are actually in reach.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>