### PR TITLE
add support for [details] tag

### DIFF
--- a/extensions/format_details.py
+++ b/extensions/format_details.py
@@ -1,0 +1,56 @@
+### Extension to convert the format of the Discourse [details]
+### tag to the format required by pymdownx.details.
+
+from markdown.preprocessors import Preprocessor
+from markdown.extensions import Extension
+import re
+
+class FixFormatting(Preprocessor):
+
+    def run(self, lines):
+
+        if '[details' in str(lines):
+            # If there is a [details.*] tag in the markdown file,
+            # process the file.
+
+            new_lines = []
+            details = 0
+
+            for line in lines:
+                if '[details' in line:
+                    # If the line introduces a details block, start
+                    # it in the required format.
+
+                    details = 1
+                    match = re.search('\[details=(.+)\]', line)
+                    if match:
+                        new_lines.append("??? details "+match.group(1)+"\n")
+                    else:
+                        new_lines.append("??? details\n")
+
+                elif '[/details]' in line:
+                    # If the line ends a details block, stop special
+                    # processing.
+
+                    details = 0
+                    new_lines.append("\n")
+
+                elif details == 1:
+                    # If the line is in a details block, indent it.
+
+                    new_lines.append("    "+line)
+
+                else:
+                    # Otherwise, use the line as is.
+
+                    new_lines.append(line)
+
+            return new_lines
+        else:
+            return lines
+
+
+class FormatDetailsExtension (Extension):
+
+    def extendMarkdown(self, md, md_globals):
+        md.preprocessors.add('formatdetails', FixFormatting(md), '_begin')

--- a/generate
+++ b/generate
@@ -36,6 +36,7 @@ import shutil
 import subprocess
 import yaml
 from extensions.include_toc import IncludeToCExtension
+from extensions.format_details import FormatDetailsExtension
 
 # Variables
 CONTENT_PATH = "content"
@@ -193,14 +194,17 @@ def md2html(content, meta):
 
     include_toc = IncludeToCExtension()
 
+    format_details = FormatDetailsExtension()
+
     return markdown.markdown(content, extensions=[codehilite, anchors,
                                                   tables, footnotes,
                                                   admonition, wikilinks,
                                                   attr_list, fenced_code,
                                                   'def_list', 'md_in_html',
-                                                  include_toc,
+                                                  include_toc, format_details,
                                                   'pymdownx.magiclink',
                                                   'pymdownx.tabbed',
+                                                  'pymdownx.details',
                                                   'nl2br'])
 
 

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -433,3 +433,8 @@ iframe {
 .tabbed-set input:nth-child(n+1):checked + label + .tabbed-content {
     display: block;
 }
+
+/* add space below a details block */
+summary {
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
Add support for the [details] tag from Discourse and
translate it into the format required for the pymdownx.details
extension.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>