### PR TITLE
css: prevent line breaks in code blocks

### DIFF
--- a/static/css/local.css
+++ b/static/css/local.css
@@ -136,6 +136,7 @@ pre {
   margin-top: .5rem;
   overflow: auto;
   max-height: 50rem;
+  white-space: pre;
 }
 
 /* prevent line breaks in code blocks */


### PR DESCRIPTION
Apparently, different tool versions create different output.
So we need to fix this on several levels ...

@stgraber What tool versions are used on the server? The generated code is different from the one I get locally.
This fix *should* work for both, but of course, I could only test it locally ...

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>