### PR TITLE
doc: fix missing line in news articles

### DIFF
--- a/generate
+++ b/generate
@@ -544,6 +544,7 @@ def gen_page(entry, override, prefix, **variables):
             # links to the rest
             if article_count <= 5:
                 full_content += article_content
+                full_content += "\n"
             elif article_count == 6:
                 full_content += "\n\n\n## %s \n" % item['meta']['str_older']
                 full_content += "- [%s](%s)\n" % (article_date,


### PR DESCRIPTION
Make sure the last line is not ignored when appending news
articles into one page.

This commit fixes issue #561.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>