### PR TITLE
doc: fix link to installation instructions

### DIFF
--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -102,7 +102,7 @@ You can also find native builds of the LXD client on [GitHub](https://github.com
 3. Select the latest build and download the suitable artifact.
 
 ## Installing from source
-To build and install LXD from source, follow the instructions in [Installing LXD from source](/lxd/docs/master/#installing-lxd-from-source).
+To build and install LXD from source, follow the instructions in [Installing LXD from source](/lxd/docs/master/installing#installing-lxd-from-source).
 
 # Initial configuration
 


### PR DESCRIPTION
We moved the installation instructions in the docs, so update
the link to it from the Getting started guide.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>