### PR TITLE
doc: rework instance information in Getting started guide

### DIFF
--- a/content/lxd/advanced-guide.md
+++ b/content/lxd/advanced-guide.md
@@ -5,42 +5,20 @@
 !!! note
 	If you haven't set up LXD yet, take a look at the [Getting-Started Guide](/lxd/getting-started-cli/) first.
 
-This Guide gives you more information about the several features of LXD.
+This guide gives you more information about several features of LXD.
 
 
 # Configuration of instances
-A list of configuration keys can be found in the [LXD documentation for instances](/lxd/docs/master/instances#keyvalue-configuration).
+See [Configure instances](/lxd/getting-started-cli/#configure-instances).
 
-You can apply them during launch of instances (see [launch flags](#lxc-launch-flags)) or add them [later](#apply-and-edit-options-later).
-
-Basically you can apply two types of configurations:
-
-- [General options](/lxd/docs/master/instances#keyvalue-configuration), including:
-    - instance start
-    - security
-    - hardware limits
-    - kernel modules
-    - snapshots
-    - user keys (for cloud-init instructions)
-    - and more
-- [Devices](/lxd/docs/master/instances#device-types), including:
-    - network
-    - storage
-    - usb
-    - sockets
-    - gpu
-    - and more
-
-
-### Difference between containers and virtual machines
 For now virtual machines support less features than containers.
 
 You can see what configuration options are available for virtual machines in the [LXD documentation for instances](/lxd/docs/master/instances#keyvalue-configuration). All categories and keys that contain the terms `virtual-machine` or `VM` are supported.
 
-### lxc launch flags
+## lxc launch flags
 You can apply flags to add configuration options to `lxc launch`.
 
-##### Short list of flags:
+### Short list of flags:
 <!-- use html table? -->
 ```
 -p profilename   # apply a profile
@@ -59,154 +37,12 @@ Usage:
 
 	    lxc launch imageserver:imagename instancename -c key1=value -c key2=value
 
+## Profiles
 
-### Profiles
-Profiles are like configuration files for instances (but they are saved in a database).
-
-#### No profile/default profile
-If you don't apply specific profiles to an instance, only the `default` profile is applied automatically.
-
-You can view the content of the `default` profile with:
-
-	lxc profile show default
-
-#### Create a profile
-Use:
-
-	lxc profile create profilename
-
-After that edit the profile, see below.
-
-#### Edit a profile
-Profiles can be edited in multiple ways:
-
-##### 1. Write a textfile and apply the content to a profile
-See [Write a profile](#write-a-profile) below for details.
-
-##### 2. Edit a profile with a terminal editor
-Use:
-
-	lxc profile edit profilename
-
-###### Choose a specific editor
-You can set the editor in `/home/user/.profile`.
-
-This will set the standard terminal editor to `nano`:
-
-	echo 'export EDITOR=nano' >> ~/.profile
-
-
-##### 3. Set specific keys in a profile
-Use:
-
-	lxc profile set profilename key=value
-
-
-#### Write a profile
-Profiles are written in yaml (markup language). So you need to follow a specific syntax.
-
-Steps:
-
-1. Create an empty textfile and name it `profilename.profile` (replace `profilename` with a name of your choice).
-2. Open the file with a texteditor of your choice.
-3. Edit and save.
-
-**Example** (`default` profile):
-
-```
-config: {}
-description: ""
-devices:
-  eth0:
-    name: eth0
-    nictype: bridged
-    parent: lxdbr0
-    type: nic
-  root:
-    path: /
-    pool: one
-    type: disk
-name: default
-used_by: []
-
-```
-
-**Explanation:**
-
-##### `config:`
-You can apply all configuration keys listed in [LXD documentation - Instance keys](https://linuxcontainers.org/lxd/docs/master/instances#keyvalue-configuration).
-
-  Example:
-
-```
-config:
-  snapshots.expiry: 1M
-  security.protection.delete: true
-  security.idmap.isolated: true
-
-```
-
-##### `description:`
-Adds a description for the profile. <!-- or the instance? -->
-Can be empty.
-
-##### `devices:`
-You can apply all configuration keys listed in [LXD documentation - Instance device types](https://linuxcontainers.org/lxd/docs/master/instances#device-types).
-
-##### `name:`
-Name of the profile (replace with a name of your choice).
-
-##### `used_by:`
-Stays empty, will indicate to which instances this profile is applied.
-
-
-#### Add the profile to LXD
-Create a new empty profile:
-
-	lxc profile create myprofile
-
-"Copy" the textfile to the new profile:
-
-	cat myprofile.profile | lxc profile edit myprofile
-
-Now you can apply this profile to an instance during [launch](#lxc-launch-flags) or later (see below).
-
-### Apply and edit options later
-You can apply/remove/modify a profile or [edit the instance configuration directly](#edit-instance-configuration).
-
-#### Apply a profile
-Use:
-
-	lxc profile add instancename profilename
-
-#### Remove a profile
-Use:
-
-	lxc profile remove instancename profilename
-
-#### Edit a profile
-Use:
-
-	lxc profile edit profilename
-
-#### Edit instance configuration
-Edit the instance configuration in a terminal editor:
-
-	lxc config edit instancename
-
-Set specific keys:
-
-	lxc config set instancename key=value
-
-
-### Show configuration
-This will show all applied configurations (including attached profiles):
-
-	lxc config show instancename -e
-
+See [Use profiles](/lxd/getting-started-cli/#use-profiles).
 
 # Cloud-init
-`cloud-init` is a software for automatic customization of a linux distribution.
+`cloud-init` is a software for automatic customization of a Linux distribution.
 
 Features include:
 

--- a/content/lxd/getting-started-cli.md
+++ b/content/lxd/getting-started-cli.md
@@ -154,55 +154,332 @@ You can configure the following options during the initial configuration of LXD.
 | Automatic image update | You can download images from image servers. In this case, images can be updated automatically. | default=`yes`; <br> If set to `yes`, LXD will update the downloaded images regularly. | LXD documentation: <br> [Image handling](/lxd/docs/master/image-handling) |
 | YAML lxd init preseed | Will display a summary of your chosen configuration options in the terminal. | default=`no` | - |
 
-# Note about virtual machines
-Since version 4.0 LXD also natively supports virtual machines and thanks to a built-in agent, they can be used almost like containers.
+
+# Instances
+LXD supports two kinds of instances:
+
+- [Containers](#containers)
+- [Virtual machines](#virtual-machines)
+
+See [Virtual machines vs. system containers](/lxd/introduction/#virtual-machines-vs-system-containers) for a comparison of these instance types.
+
+## Containers
+Containers are the default instance type for LXD. They are currently the most complete implementation of LXD instances and support more features than virtual machines.
+
+Containers are implemented through the use of `liblxc` (LXC).
+
+## Virtual machines
+Virtual machines are natively supported since version 4.0 of LXD. Thanks to a built-in agent, they can be used almost like containers.
 
 LXD uses `qemu` to provide the VM functionality.
 
-See [below](#launch-an-instance) for how to start a virtual machine.
-
-You can find more information about virtual machines in our forum[^1].
-<!-- You can find more information in the Advanced Guide. -->
-
 !!! note
-	For now virtual machines support less features than containers. See [Advanced Guide - Instance configuration](/lxd/advanced-guide#difference-between-containers-and-virtual-machines) for details.
+	Currently, virtual machines support fewer features than containers, but the plan is to support the same set of features for both instance types in the future.
 
-# LXD client
-The LXD client `lxc` is a command tool to manage your LXD servers.
+    To see which features are available for virtual machines, check the condition column in the [Instance configuration](/lxd/docs/master/instances#keyvalue-configuration) documentation.
 
-## Overview
-The following command will give you an overview of all available commands and options:
+## Launch an instance
+Use the `lxc launch` command to launch an instance. You must specify the image that you want to launch and a name for the instance that you are creating.
+
+Images for various operating systems are available on the built-in remote image servers. See [Images](#images) for more information. You must specify the name of the image server and the name of the image.
+
+### Launch a container
+
+Enter the following command to launch a container:
+
+	lxc launch <image_server>:<image_name> <instance_name>
+
+For example, to launch a container with a Ubuntu 20.04 image from the `images` server using the instance name `ubuntu-container`, enter the following command:
+
+    lxc launch images:ubuntu/20.04 ubuntu-container
+
+### Launch a virtual machine
+
+Enter the following command to launch a virtual machine:
+
+	lxc launch <image_server>:<image_name> <instance_name> --vm
+
+For example, to launch a virtual machine with a Ubuntu 20.04 image from the `images` server using the instance name `ubuntu-vm`, enter the following command:
+
+    lxc launch images:ubuntu/20.04 ubuntu-vm --vm
+
+## Manage instances
+Use the LXD client tool `lxc` to manage your LXD instances.
+
+The following command gives an overview of all available commands and options:
 
 	lxc
 
-Use `lxc [command] --help` for more information about a command, like flags and further options.
+Use `lxc <command> --help` for more information about a command, like flags and further options.
 
-## Launch an instance
-You can launch an instance with the `lxc launch` command.
+### List instances
 
-To launch a container:
+Enter the following command to list all instances:
 
-	lxc launch imageserver:imagename instancename
+    lxc list
 
-To launch a virtual machine:
+You can filter the instances that are displayed, for example, by type or status:
 
-	lxc launch imageserver:imagename instancename --vm
+    lxc list type=container
+    lxc list status=running
 
-In the commands above, replace:
+You can also filter by name. To list several instances, use a regular expression for the name. For example:
 
-- `imageserver` with the name of a built-in or added image server (e.g. `ubuntu` or `images`).
-- `imagename` with the name of an image (e.g. `20.04` or `debian/11`).   See [Section "Images"](#images) for details.
-- `instancename` with a name of your choice (e.g. `ubuntuone`). If left empty, LXD will pick a random name.
+    lxc list ubuntu.*
 
-For example, to create a container based on the Ubuntu `Focal Fossa` image (provided by LXD) with the instancename `ubuntuone`, enter the following command:
+Enter `lxc list --help` to see all filter options.
 
-	lxc launch ubuntu:20.04 ubuntuone
+### Show information about an instance
 
-## Configuration of instances
-See [Advanced Guide - Instance Configuration](/lxd/advanced-guide#configuration-of-instances).
+Enter the following command to show detailed information about an instance:
 
+    lxc info <instance_name>
 
-## Images
+Add `--show-log` to the command to show the latest log lines for the instance:
+
+    lxc info <instance_name> --show-log
+
+### Start and stop an instance
+
+Enter the following command to start an instance:
+
+	lxc start <instance_name>
+
+You will get an error if the instance does not exist or if it is running already.
+
+Enter the following command to stop an instance:
+
+    lxc stop <instance_name>
+
+You will get an error if the instance does not exist or if it is not running.
+
+### Delete an instance
+
+If you don't need an instance anymore, you can remove it. The instance must be stopped before you can delete it.
+
+Enter the following command to delete an instance:
+
+    lxc delete <instance_name>
+
+!!! warning
+	This command permanently deletes the instance and all snapshots.
+
+    See [Prevent accidental deletion of an instance](/lxd/advanced-guide/#prevent-accidental-deletion-of-an-instance) for instructions on how to avoid accidental deletion.
+
+## Configure instances
+See [Instance configuration](/lxd/docs/master/instances) in the LXD documentation for a list of configuration options that you can specify for your instances.
+
+The instance configuration consists of different categories:
+
+[Instance properties](/lxd/docs/master/instances#properties)
+:   Properties that are set when the instance is created, for example, the instance name and architecture. These properties cannot be changed in the same way as other configuration options.
+
+[Instance options](/lxd/docs/master/instances#keyvalue-configuration)
+:   Configuration options related directly to the instance, for example, startup options, security settings, hardware limits, kernel modules, snapshots and user keys.
+
+[Instance devices](/lxd/docs/master/instances#device-types)
+:   Devices that are attached to an instance, for example, network interfaces, mount points, USB and GPU devices. These devices can have *instance device options*, depending on the type of the instance device.
+
+Check the condition column for each configuration option to see if it is available for the instance type that you are using.
+
+You can configure these options either when launching an instance or later at runtime. You can also create profiles to store and apply sets of configuration options.
+
+### Specify configuration when launching an instance
+To specify instance options when launching an instance, use the `--config` (or `-c` for short) flag with the `lxc launch` command. Note that you can only specify instance options with the `--config` flag. You cannot add and configure instance devices with this method.
+
+For example, to limit the container resources to one vCPU and 192 MiB of RAM, add the following flags:
+
+    lxc launch images:ubuntu/20.04 ubuntu-limited -c limits.cpu=1 -c limits.memory=192MiB
+
+To launch an instance with a full configuration (which can also include instance devices), specify the configuration through a `.yaml` file. Check the contents of an existing instance configuration for the required markup (see [Display instance configuration](#display-instance-configuration)).
+
+For example, to launch a container with the configuration from `config.yaml`, enter the following command:
+
+    lxc launch images:ubuntu/20.04 ubuntu-config < config.yaml
+
+You can also specify configuration options when launching an instance by applying one or more profiles. See [Use profiles](#use-profiles) for more information.
+
+### Update configuration at runtime
+To update instance options while the instance is running, use the `lxc config set` command. You need to specify the instance name and the key and value of the instance option:
+
+    lxc config set <instance_name> <option_key>=<option_value> <option_key>=<option_value> ...
+
+For example, to change the memory limit for your container, enter the following command:
+
+    lxc config set ubuntu-limited limits.memory=128MiB
+
+To add and configure an instance device for your instance, use the `lxc config device add` command. You need to specify the instance name, a device name, the device type and maybe device options (depending on the device type):
+
+    lxc config device add <instance_name> <device_name> <device_type> <device_option_key>=<device_option_value> <device_option_key>=<device_option_value> ...
+
+For example, to add the storage at `/share/c1` on the host system to your instance at path `/opt`, enter the following command:
+
+    lxc config device add ubuntu-container disk-storage-device disk source=/share/c1 path=/opt
+
+To configure instance device options for an instance device that you have added already, use the `lxc config device set` command.
+
+### Display instance configuration
+Enter the following command to display the current configuration of your instance:
+
+    lxc config show <instance_name> -e
+
+The configuration is displayed in [YAML](https://en.wikipedia.org/wiki/YAML) format.
+
+### Use profiles
+Profiles store a set of configuration options. They can contain instance options, instance devices and instance device options.
+
+You can apply any number of profiles to an instance. They are applied in the order they are specified, so the last profile to specify a specific key takes precedence. However, instance-specific configuration always overrides the configuration coming from the profiles.
+
+When applying a profile that contains configuration options that are not suitable for the instance type, these configuration options are ignored and do not result in an error.
+
+If you don't specify any profiles when launching a new instance, the `default` profile is applied automatically. This profile defines a network interface and a root disk. The `default` profile cannot be renamed or removed.
+
+#### View profiles
+Enter the following command to display a list of all available profiles:
+
+    lxc profile list
+
+Enter the following command to display the contents of a profile:
+
+    lxc profile show <profile_name>
+
+#### Create an empty profile
+Enter the following command to create an empty profile:
+
+    lxc profile create <profile_name>
+
+#### Edit a profile
+You can either set specific configuration options or edit the full profile in YAML format.
+
+##### Set specific options for a profile
+To set an instance option for a profile, use the `lxc profile set` command. You need to specify the profile name and the key and value of the instance option:
+
+    lxc profile set <profile_name> <option_key>=<option_value> <option_key>=<option_value> ...
+
+To add and configure an instance device for your profile, use the `lxc profile device add` command. You need to specify the profile name, a device name, the device type and maybe device options (depending on the device type):
+
+    lxc profile device add <instance_name> <device_name> <device_type> <device_option_key>=<device_option_value> <device_option_key>=<device_option_value> ...
+
+To configure instance device options for an instance device that you have added to the profile already, use the `lxc profile device set` command.
+
+##### Edit the full profile
+Instead of setting each configuration option separately, you can provide all options at once in [YAML](https://en.wikipedia.org/wiki/YAML) format.
+
+Check the contents of an existing profile or instance configuration for the required markup. For example, the `default` profile could look like this:
+
+    config: {}
+    description: Default LXD profile
+    devices:
+      eth0:
+        name: eth0
+        network: lxdbr0
+        type: nic
+      root:
+        path: /
+        pool: default
+        type: disk
+    name: default
+    used_by:
+
+Instance options are provided as array under `config`. Instance devices and instance device options are provided under `devices`.
+
+To edit a profile using your standard terminal editor, enter the following command:
+
+    lxc profile edit <profile_name>
+
+Alternatively, you can create a YAML file (for example, `profile.yaml`) with the configuration and write the configuration to the profile with the following command:
+
+    lxc profile edit <profile_name> < profile.yaml
+
+#### Apply a profile to an instance
+Enter the following command to apply a profile to an instance:
+
+    lxc profile add <instance_name> <profile_name>
+
+!!! Tip
+    Check the configuration after adding the profile: `lxc config show <instance_name>`
+
+    You will see that your profile is now listed under `profiles`. However, the configuration options from the profile are not shown under `config` (unless you add the `-e` flag). This is because they are taken from the profile and not the configuration of the instance.
+
+    This means that if you edit a profile, the changes are automatically applied to all instances that use the profile.
+
+You can also specify profiles when launching an instance by adding the `--profile`  (or `-p` for short) flag:
+
+    lxc launch <image> <instance_name> -p <profile> -p <profile> ...
+
+#### Remove a profile from an instance
+Enter the following command to remove a profile from an instance:
+
+    lxc profile remove <instance_name> <profile_name>
+
+## Run commands
+To run commands on your instance, either pass them from the host machine or log on to your container.
+
+### Run commands from the host
+To run a single command from the terminal of the host machine, use the `lxc exec` command:
+
+    lxc exec <instance_name> -- <command>
+
+For example, enter the following command to update the package list on your container:
+
+    lxc exec ubuntu-container -- apt-get update
+
+### Get shell access
+!!! note
+    The following instructions assume that your container has the `/bin/bash` command. If it doesn't, change the command appropriately.
+
+Start a shell in your container to run commands directly in the container. Enter the following command:
+
+    lxc exec <instance_name> -- /bin/bash
+
+By default, you are logged in as root user. If you want to log in as a different user, enter the following command:
+
+    lxc exec <instance_name> -- su --login <user_name>
+
+!!! note
+    In many containers, you must create a user first.
+
+To exit the container shell, enter `exit` or press `Ctrl`+`d`.
+
+### Log on to a virtual machine
+If you are running a virtual machine, you can log on to its console with the following command:
+
+	lxc console <vm_name>
+
+To detach, press `Ctrl`+`a`-`q`.
+
+## Access files
+You can access the files from your container and pull them to the host machine, or push files from the host machine to the container.
+
+### Pull files from the container
+
+Enter the following command to pull a file from the container:
+
+    lxc file pull <instance_name>/<path_to_file> <location_on_host>
+
+For example, to pull the `/etc/hosts` file to the current folder, enter the following command:
+
+    lxc file pull ubuntu-container/etc/hosts .
+
+Instead of pulling the container file into a file on the host system, you can also pull it to stdin and pipe it into another command. This can be useful, for example, to check a log file:
+
+    lxc file pull ubuntu-container/var/log/syslog - | less
+
+To pull a folder with all contents, enter the following command:
+
+    lxc file pull -r <instance_name>/<path_to_folder> <location_on_host>
+
+#### Push files to the container
+
+Enter the following command to push a file to the container:
+
+    lxc file push <location_on_host> <instance_name>/<path_to_file>
+
+To push a folder with all contents, enter the following command:
+
+    lxc file push -r <location_on_host> <instance_name>/<path_to_folder>
+
+# Images
 Instances are based on Images, which contain a basic operating system (for example a linux distribution) and some other LXD-related information.
 
 In the following we will use the built-in remote image servers ([see below](#use-remote-image-servers)).
@@ -247,104 +524,6 @@ Show all 64-bit Debian images:
 
 ### Images for virtual machines
 It is recommended to use the `cloud` variants of images (visible by the `cloud`-tag in their `ALIAS`). They include cloud-init and the LXD-agent. They also increase their size automatically and are tested daily.
-
-## Instance management
-List all instances:
-
-    lxc list
-
-### Start/stop
-Start an instance:
-
-	lxc start instancename
-
-Stop an instance:
-
-    lxc stop instancename
-
-### Shell/terminal inside container
-Get a shell inside a container:
-
-    lxc exec instancename -- /bin/bash
-
-By default you are logged in as root:
-
-```bash
-root@containername:~#
-
-```
-
-#### Log in as a user instead
-!!! note
-    In many containers you need to create a user first.
-
-```
-lxc exec instancename -- su --login username
-```
-
-Exit the container shell, with:
-
-```bash
-username@containername:~# exit
-
-```
-
-### Run command from host terminal
-Run a single command from host's terminal:
-
-    lxc exec containername -- apt-get update
-
-### Shell/terminal inside virtual machine
-You can see your VM boot with:
-
-	lxc console instancename
-
-(detach with ctrl+a-q)
-
-Once booted, VMs with the LXD-agent built-in, can be accessed with:
-
-	lxc exec instancename bash
-
-Exit the VM shell, with:
-
-	exit
-
-### Copy files and folders between container and host
-#### Copy from an instance to host
-
-Pull a file with:
-
-    lxc file pull instancename/path-in-container path-on-host
-
-Pull a folder with:
-
-    lxc file pull -r instancename/path-in-container path-on-host
-
-For example:
-
-    lxc file pull instancename/etc/hosts .
-
-#### Copy from host to instance
-
-Push a file with:
-
-    lxc file push path-on-host instancename/path-in-container
-
-Push a folder with:
-
-    lxc file push -r path-on-host instancename/path-in-container
-
-### Remove instance
-
-!!! warning
-	This will delete the instance including all snapshots. Deletion will be final in most cases and restore is unlikely!
-
-    See [Tips & Tricks in Advanced Guide](/lxd/advanced-guide/#prevent-accidental-deletion-of-an-instance) on how to avoid accidental deletion.
-
-Use:
-
-    lxc delete instancename
-
 
 # Further information & links
 


### PR DESCRIPTION
Rework the information about working with instances in the
Getting started guide, to make it easier to move this information
over to the documentation in the future.
Remove content from the advanced guide that would be duplicated.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>