### PR TITLE
doc: remove snap installation for lxc

### DIFF
--- a/content/lxc/getting-started.md
+++ b/content/lxc/getting-started.md
@@ -40,10 +40,6 @@ On such an Ubuntu system, installing LXC is as simple as:
 
     sudo apt-get install lxc
 
-or
-
-    sudo snap install lxd
-
 Your system will then have all the LXC commands available, all its templates as well as the python3 binding should you want to script LXC.
 
 


### PR DESCRIPTION
There is no snap for lxc, and the lxd snap does not install
the required binaries.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>