### PR TITLE
Update many markdown file for Japanese contents

### DIFF
--- a/content/distrobuilder/contribute.ja.md
+++ b/content/distrobuilder/contribute.ja.md
@@ -8,8 +8,7 @@ distrobuilder の現時点の開発バージョンは GitHub からクローン�
     git clone git://github.com/lxc/distrobuilder
 
 <!--
-Contributions sent upstream for review must be based on the current git tree
-and not on stable releases, unless the bug only affects a stable release.
+Contributions sent upstream for review must be based on the current git tree and not on stable releases, unless the bug only affects a stable release.
 -->
 レビューのためにパッチを送る場合は、バグが stable リリースにのみ影響する場合を除いて、stable リリースでなく現時点の開発バージョンのツリーを元にしてください。
 

--- a/content/distrobuilder/introduction.ja.md
+++ b/content/distrobuilder/introduction.ja.md
@@ -12,11 +12,7 @@ It's used to build all our official images available on [our image server](https
 [私たちのイメージサーバ](https://images.linuxcontainers.org) にある公式イメージすべての作成に使っています。
 
 <!--
-The image definition is a YAML document which describes the source of the
-image, its package manager, what packages to install/remove for specific
-image variants, os releases and architectures, as well as additional
-files to generate and arbitrary actions to execute as part of the image
-build process.
+The image definition is a YAML document which describes the source of the image, its package manager, what packages to install/remove for specific image variants, os releases and architectures, as well as additional files to generate and arbitrary actions to execute as part of the image build process.
 -->
 イメージの定義は YAML 文書です。これはイメージのソース、そのイメージで使うパッケージ管理ツール、OS リリースやアーキテクチャなどの特定のイメージの種類でどのパッケージをインストールしたり削除したりするかを記述します。
 また、イメージのビルドプロセス中に生成して追加するファイルや、任意のアクションも記述します。
@@ -51,7 +47,6 @@ distrobuilder is written in Go, it's free software and is developed under the Ap
 distrbuilder は Go で書かれています。フリーソフトウェアであり、Apache 2 ライセンスの元で開発されています。
 
 <!--
-There are no CLA or similar legal agreements required to contribute to distrobuilder,
-however we do require commits be signed-off (following the DCO - Developer Certificate of Ownership).
+There are no CLA or similar legal agreements required to contribute to distrobuilder, however we do require commits be signed-off (following the DCO - Developer Certificate of Ownership).
 -->
 distrobuilder に貢献するのに必要な CLA や同様の法的合意はありません。しかし、コミットを signed-off する必要があります (DCO - Developer Certificate of Ownership に従います)。

--- a/content/lxc/contribute.ja.md
+++ b/content/lxc/contribute.ja.md
@@ -8,14 +8,12 @@ LXC の現時点の開発バージョンは GitHub からクローンできま�
     git clone git://github.com/lxc/lxc
 
 <!--
-Source tarballs from the various stable releases are also available in
-the [downloads](/lxc/downloads/) section.
+Source tarballs from the various stable releases are also available in the [downloads](/lxc/downloads/) section.
 -->
 stable リリースの各バージョンのソース tarball は [ダウンロードページ](/lxc/downloads/) から取得できます。
 
 <!--
-Patches sent upstream for review must be based on the current git tree
-and not on stable releases, unless the bug only affects a stable release.
+Patches sent upstream for review must be based on the current git tree and not on stable releases, unless the bug only affects a stable release.
 -->
 レビューのためにパッチを送る場合は、バグが stable リリースにのみ影響する場合を除いて、stable リリースでなく現時点の開発バージョンのツリーを元にしてください。
 
@@ -37,8 +35,7 @@ and if you forgot "-s" on a previous commit : `git commit --amend -s`
 
 ## <!-- The mailing-list way -->メーリングリストへのパッチの投稿
 <!--
-You may contribute to LXC either by sending a patch or patchset directly
-on the [lxc-devel mailing-list](https://lists.linuxcontainers.org/listinfo/lxc-devel).
+You may contribute to LXC either by sending a patch or patchset directly on the [lxc-devel mailing-list](https://lists.linuxcontainers.org/listinfo/lxc-devel).
 -->
 パッチ、もしくはパッチセットを直接 [lxc-devel メーリングリスト](https://lists.linuxcontainers.org/listinfo/lxc-devel) に送ることによって LXC に貢献できます。
 

--- a/content/lxc/documentation.ja.md
+++ b/content/lxc/documentation.ja.md
@@ -6,19 +6,13 @@ For the command line tools, please refer to the [man pages.](/lxc/manpages/)
 
 # API
 <!--
-LXC ships with a stable C API and a bunch of bindings. That API is stable and properly versioned.
-We may make additions to the liblxc1 API in LXC releases but will not remove or change existing symbols
-without calling it liblxc2.
+LXC ships with a stable C API and a bunch of bindings. That API is stable and properly versioned. We may make additions to the liblxc1 API in LXC releases but will not remove or change existing symbols without calling it liblxc2.
 -->
 LXC は C の API といくつかの言語のバインディングと共にリリースされています。API は同じバージョンでは不変で適切にバージョン管理されています。
 LXC のリリースで liblxc1 には追加がなされることはあっても、API が削除されたり既存のシンボルが変更されることは liblxc2 になるまではありません。
 
 <!--
-The first LXC version to ship with the stable API was LXC 1.0.0.
-Only symbols listed in
-[lxccontainer.h](https://github.com/lxc/lxc/blob/master/src/lxc/lxccontainer.h)
-are part of the API, everything else is internal to LXC
-and can change at any point.
+The first LXC version to ship with the stable API was LXC 1.0.0. Only symbols listed in [lxccontainer.h](https://github.com/lxc/lxc/blob/master/src/lxc/lxccontainer.h) are part of the API, everything else is internal to LXC and can change at any point.
 -->
 安定版 API としてリリースされた最初の LXC のバージョンは LXC 1.0.0 でした。
 [lxccontainer.h](https://github.com/lxc/lxc/blob/master/src/lxc/lxccontainer.h) にリストされているシンボルだけが API を構成します。その他全ては LXC の内部利用であり、いつでも変更される可能性があります。
@@ -105,14 +99,12 @@ And now a simple example of how to use the API to create, start, stop and destro
 
 ## Python
 <!--
-The python bindings are typically very close to the C API except for the part where it exports
-proper objects instead of structs.
+The python bindings are typically very close to the C API except for the part where it exports proper objects instead of structs.
 -->
 python バインディングは、構造体に代わりに適切なオブジェクトがエクスポートされる部分を除いては、一般的に C API に最も近いです。
 
 <!--
-The binding is made in two parts, the raw "\_lxc" C extension and the "lxc" python overlay
-which provides the improve user experience.
+The binding is made in two parts, the raw "\_lxc" C extension and the "lxc" python overlay which provides the improve user experience.
 -->
 バインディングは 2 つの部分から作られています。生の (raw) "\_lxc" C 拡張と、ユーザの使い勝手を改良する "lxc" python オーバーレイです。
 
@@ -199,8 +191,7 @@ C の例と全く同じ例は以下のようになります:
         sys.exit(1)
 
 <!--
-A great feature of the python binding is the ability to run a function in the container's context
-as can be seen in the example below of a script updating all of your containers:
+A great feature of the python binding is the ability to run a function in the container's context as can be seen in the example below of a script updating all of your containers:
 -->
 python バインディングの大きな特徴は、以下の全てのコンテナを更新するスクリプトの例でわかるように、コンテナのコンテキスト内で関数を実行できることです:
 

--- a/content/lxc/downloads.ja.md
+++ b/content/lxc/downloads.ja.md
@@ -2,22 +2,19 @@
 # ディストリビューションでのインストール <!-- Distribution packages -->
 
 <!--
-LXC is included in most Linux distributions.
-In most cases installing it is as simple as selecting it in your package manager.
+LXC is included in most Linux distributions. In most cases installing it is as simple as selecting it in your package manager.
 -->
 LXC は大部分の Linux ディストリビューションに含まれています。
 インストールする場合は、ディストリビューションのパッケージマネージャで LXC を選択するのが簡単でしょう。
 
 <!--
-Distributions also often provide backports of newer versions of LXC for their stable releases.
-You may want to look for that, especially if your distribution doesn't include LXC 4.0 or 3.0.
+Distributions also often provide backports of newer versions of LXC for their stable releases. You may want to look for that, especially if your distribution doesn't include LXC 4.0 or 3.0.
 -->
 ディストリビューションでは、ディストリビューションの stable リリースに対する LXC のより新しいバージョンのバックポートが提供されるケースも多いでしょう。
 LXC 4.0 や 3.0 がディストリビューションの stable リリースに含まれない場合は特に、それを使うことも選択肢の一つでしょう。
 
 <!--
-For production environment, try to stick to LXC 4.0.x or 3.0.x as these are the long term,
-stable releases which we will support until June 2025 (4.0.x) and June 2023 (3.0.x) respectively.
+For production environment, try to stick to LXC 4.0.x or 3.0.x as these are the long term, stable releases which we will support until June 2025 (4.0.x) and June 2023 (3.0.x) respectively.
 -->
 Production 環境では、長期サポート版の stable リリースである LXC 4.0.x もしくは 3.0.x を使い続けることをお勧めします。それぞれ 2025 年 6 月（4.0.x）、2023 年 6 月（3.0.x）までサポートします。
 
@@ -59,8 +56,7 @@ You can clone those directly with:
 # リリース版 tarball <!-- Release tarballs -->
 
 <!--
-Stable release tarballs are available for download below.
-All the tarball are GPG signed by one of the maintainers.
+Stable release tarballs are available for download below. All the tarball are GPG signed by one of the maintainers.
 -->
 Stable リリース版の tarball は以下から取得できます。
 tarball はすべて全てメンテナの GPG による署名が行われています。

--- a/content/lxc/getting-started.ja.md
+++ b/content/lxc/getting-started.ja.md
@@ -61,28 +61,23 @@ Recommended libraries:
 # インストール<!-- Installation -->
 
 <!--
-In most cases, you'll find recent versions of LXC available for your Linux distribution.
-Either directly in the distribution's package repository or through some backport channel.
+In most cases, you'll find recent versions of LXC available for your Linux distribution. Either directly in the distribution's package repository or through some backport channel.
 -->
 通常はあなたがお使いのディストリビューションが、ディストリビューションのパッケージリポジトリもしくはバックポート用のチャンネル経由で、最新版の LXC を提供しているでしょう。
 
 <!--
-For your first LXC experience, we recommend you use a recent supported release,
-such as a recent bugfix release of LXC 4.0.
+For your first LXC experience, we recommend you use a recent supported release, such as a recent bugfix release of LXC 4.0.
 -->
 最初に LXC を使う場合は、LXC 4.0 の最新のバグフィックスのなされたバージョンのような、最新のサポート版リリースをお使いになることを推奨します。
 
 <!--
-If using Ubuntu, we recommend you use Ubuntu 18.04 LTS as your container host.
-LXC bugfix releases are available directly in the distribution package repository
-shortly after release and those offer a clean (unpatched) upstream experience.
+If using Ubuntu, we recommend you use Ubuntu 18.04 LTS as your container host. LXC bugfix releases are available directly in the distribution package repository shortly after release and those offer a clean (unpatched) upstream experience.
 -->
 Ubuntu を使っている場合、コンテナホストとして Ubuntu 18.04 LTS を使うことを推奨します。
 LXC のバグフィックスリリースは、リリース後すぐに直接ディストリビューションのパッケージリポジトリ経由で利用可能で、パッチの当たっていないクリーンな最新版を提供します。
 
 <!--
-Ubuntu is also one of the few (if not only) Linux distributions to come by default
-with everything that's needed for safe, unprivileged LXC containers.
+Ubuntu is also one of the few (if not only) Linux distributions to come by default with everything that's needed for safe, unprivileged LXC containers.
 -->
 Ubuntu は、安全な非特権の LXC コンテナのために必要な全てをデフォルトで揃えている Linux ディストリビューションのいくつかのうちの 1 つです (Ubuntu 以外にもそのようなディストリビューションは存在します)。
 
@@ -108,11 +103,7 @@ Linux カーネルに必要な機能を持っているかどうかをチェッ�
 # 非特権コンテナの作成 <!-- Creating unprivileged containers as a user -->
 
 <!--
-Unprivileged containers are the safest containers.
-Those use a map of uid and gid to allocate a range of uids and gids to a container.
-That means that uid 0 (root) in the container is actually something like uid 100000
-outside the container. So should something go very wrong and an attacker manages
-to escape the container, they'll find themselves with about as many rights as a nobody user.
+Unprivileged containers are the safest containers. Those use a map of uid and gid to allocate a range of uids and gids to a container. That means that uid 0 (root) in the container is actually something like uid 100000 outside the container. So should something go very wrong and an attacker manages to escape the container, they'll find themselves with about as many rights as a nobody user.
 -->
 非特権コンテナは最も安全なコンテナです。
 非特権コンテナでは、コンテナで使う範囲の uid と gid を割り当てるために、uid と gid のマッピングを使います。
@@ -134,32 +125,25 @@ Unfortunately this also means that the following common operations aren't allowe
   * マッピングが存在していない uid/gid に対する操作
 
 <!--
-Because of that, most distribution templates simply won't work with those.
-Instead you should use the "download" template which will provide you with pre-built images
-of the distributions that are known to work in such an environment.
+Because of that, most distribution templates simply won't work with those. Instead you should use the "download" template which will provide you with pre-built images of the distributions that are known to work in such an environment.
 -->
 このため、ほとんどのディストリビューションのコンテナテンプレートは動作しないでしょう。
 代わりに、このような非特権の環境でも動くことを確認した、あらかじめビルド済みのディストリビューションのイメージを提供する "download" テンプレートを使う必要があります。
 
 <!--
-The following instructions assume the use of a recent Ubuntu system or an alternate Linux 
-distribution offering a similar experience, i.e., a recent kernel and a recent version of 
-shadow, as well as libpam-cgfs and default uid/gid allocation.
+The following instructions assume the use of a recent Ubuntu system or an alternate Linux distribution offering a similar experience, i.e., a recent kernel and a recent version of shadow, as well as libpam-cgfs and default uid/gid allocation.
 -->
 このあとの説明は、最新のカーネル、最新バージョンの shadow、libpam-cgfs、デフォルトの uid/gid 割り当てと言った、最新の Ubuntu や同等の Linux ディストリビューションを使用していると仮定して行います。
 
 <!--
-First of all, you need to make sure your user has a uid and gid map defined in /etc/subuid and /etc/subgid.
-On Ubuntu systems, a default allocation of 65536 uids and gids is given to every new user on the system,
-so you should already have one. If not, you'll have to use usermod to give yourself one.
+First of all, you need to make sure your user has a uid and gid map defined in /etc/subuid and /etc/subgid. On Ubuntu systems, a default allocation of 65536 uids and gids is given to every new user on the system, so you should already have one. If not, you'll have to use usermod to give yourself one.
 -->
 まず第一に、お使いの (非特権コンテナを使おうとする) ユーザが /etc/subuid と /etc/subgid で定義された uid/gid のマッピングを持っている必要があります。
 Ubuntu では、デフォルトで 65536 個の uid と gid の割り当てが、システム上で全ての新規ユーザに与えられますので、Ubuntu をお使いの場合はすでにそのマッピングを持っているはずです。
 もしマッピングがない場合は、usermod コマンドを使って割り当てる必要があります。
 
 <!--
-Next up is /etc/lxc/lxc-usernet which is used to set network devices quota for unprivileged users.
-By default, your user isn't allowed to create any network device on the host, to change that, add:
+Next up is /etc/lxc/lxc-usernet which is used to set network devices quota for unprivileged users. By default, your user isn't allowed to create any network device on the host, to change that, add:
 -->
 次に、非特権ユーザに与えるネットワークデバイスの範囲を設定するために使う /etc/lxc/lxc-usernet を設定します。
 デフォルトでは、ホスト上で全くネットワークデバイスを割り当てできないことになっていますので、このファイルに以下のような設定を追加します:
@@ -272,21 +256,18 @@ And finally removing it with:
 # root で非特権コンテナを作成する <!-- Creating unprivileged containers as root -->
 
 <!--
-To run a system-wide unprivileged container (that is, an unprivileged container started by root)
-you'll need to follow only a subset of the steps above.
+To run a system-wide unprivileged container (that is, an unprivileged container started by root) you'll need to follow only a subset of the steps above.
 -->
 システム全体で非特権コンテナを実行するには (これは root が非特権コンテナを実行するということです)、以下のような前述のステップの一部が必要なだけです。
 
 <!--
-Specifically, you need to manually allocate a uid and gid range to root in /etc/subuid and /etc/subgid.
-And then set that range in /etc/lxc/default.conf using lxc.idmap entries similar to those above.
+Specifically, you need to manually allocate a uid and gid range to root in /etc/subuid and /etc/subgid. And then set that range in /etc/lxc/default.conf using lxc.idmap entries similar to those above.
 -->
 具体的に言うと、root に対して割り当てる uid と gid の範囲を /etc/subuid と /etc/subgid に割り当てる必要があります。
 そして、その範囲を先と同様に /etc/lxc/default.conf に lxc.idmap を使って設定します。
 
 <!--
-And that's it. Root doesn't need network devices quota and uses the
-global configuration file so the other steps don't apply.
+And that's it. Root doesn't need network devices quota and uses the global configuration file so the other steps don't apply.
 -->
 以上です。root はネットワークデバイスの範囲を設定する必要はありません。グローバルの設定ファイルの設定を使いますので、このステップは不要です。
 
@@ -303,15 +284,12 @@ Privileged containers are containers created by root and running as root.
 特権コンテナは root が作成し、root が実行します。
 
 <!--
-Depending on the Linux distribution, they may be protected by some capability dropping, apparmor profiles,
-selinux context or seccomp policies but ultimately, the processes still run as root and so you should never
-give access to root inside a privileged container to an untrusted party.
+Depending on the Linux distribution, they may be protected by some capability dropping, apparmor profiles, selinux context or seccomp policies but ultimately, the processes still run as root and so you should never give access to root inside a privileged container to an untrusted party.
 -->
 ディストリビューションによっては、特権コンテナはケーパビリティをいくつか落としたり、apparmor プロファイルや、SELinux コンテキスト、seccomp ポリシーでプロテクトされているかもしれません。しかし、最終的にはプロセスは root 権限で実行されますので、信頼できないユーザに特権コンテナ内の root 権限を与えるべきではありません。
 
 <!--
-If you still have to create privileged containers, it's quite simple. Simply don't do any of the configuration
-described above and LXC will create privileged containers.
+If you still have to create privileged containers, it's quite simple. Simply don't do any of the configuration described above and LXC will create privileged containers.
 -->
 特権コンテナを作成する必要がある場合は、非常に簡単です。単純に前述のようなステップを踏むことなく、特権コンテナが作成されます。
 

--- a/content/lxc/introduction.ja.md
+++ b/content/lxc/introduction.ja.md
@@ -1,9 +1,7 @@
 # LXC について <!-- What's LXC? -->
 
 <!--
-LXC is a userspace interface for the Linux kernel containment features.
-Through a powerful API and simple tools, it lets Linux users easily create
-and manage system or application containers.
+LXC is a userspace interface for the Linux kernel containment features. Through a powerful API and simple tools, it lets Linux users easily create and manage system or application containers.
 -->
 LXC は Linux カーネルが持つコンテナ機能のためのユーザスペースのインターフェースです。
 Linux ユーザがシステムコンテナやアプリケーションコンテナを簡単に作成したり管理したりするためのパワフルな API とシンプルなツールを提供しています。
@@ -23,9 +21,7 @@ Current LXC uses the following kernel features to contain processes:
  * CGroups (control groups)
 
 <!--
-LXC containers are often considered as something in the middle between a chroot and
-a full fledged virtual machine. The goal of LXC is to create an environment as close as possible
-to a standard Linux installation but without the need for a separate kernel.
+LXC containers are often considered as something in the middle between a chroot and a full fledged virtual machine. The goal of LXC is to create an environment as close as possible to a standard Linux installation but without the need for a separate kernel.
 -->
 LXC はよく強力な chroot と本格的な仮想マシンの中間のようなものに見なされます。
 LXC の目的は、可能な限り標準的な Linux のインストール環境に近く、しかし別々のカーネルは必要ないような環境を作ることです。 
@@ -49,9 +45,7 @@ LXC はいくつかのコンポーネントから構成されています。
 
 # ライセンス <!-- Licensing -->
 <!--
-LXC is free software, most of the code is released under the terms of the GNU LGPLv2.1+ license,
-some Android compatibility bits are released under a standard 2-clause BSD license
-and some binaries and templates are released under the GNU GPLv2 license.
+LXC is free software, most of the code is released under the terms of the GNU LGPLv2.1+ license, some Android compatibility bits are released under a standard 2-clause BSD license and some binaries and templates are released under the GNU GPLv2 license.
 -->
 LXC はフリーソフトウェアで、コードのほとんどの部分が GNU LGPLv2.1+ の条項に基づいてリリースされています。
 Android 互換である部分は二条項BSDライセンス (2-clause BSD license) に基づいており、GNU GPLv2 ライセンスに基づいてリリースされているバイナリやテンプレートもあります。 
@@ -64,20 +58,17 @@ The default license for the project is the GNU LGPLv2.1+.
 # サポート <!-- Support -->
 
 <!--
-LXC's stable release support relies on the Linux distributions
-and their own commitment to pushing stable fixes and security updates.
+LXC's stable release support relies on the Linux distributions and their own commitment to pushing stable fixes and security updates.
 -->
 LXC の stable リリースは各 Linux ディストリビューションの stable に対する修正とセキュリティアップデートのポリシーに依存します。
 
 <!--
-Based on the needs and available resources from the various distributions,
-specific versions of LXC can enjoy long term support with frequent bugfix updates.
+Based on the needs and available resources from the various distributions, specific versions of LXC can enjoy long term support with frequent bugfix updates.
 -->
 各種ディストリビューションでのニーズと利用可能なリソース次第で、そのディストリビューションで LXC の特定のバージョンが頻繁なバグフィックスの更新が行われる長期サポートで利用できる可能性があります。
 
 <!--
-Other releases will typically be maintained on a best effort basis which
-typically means until the next stable release is out.
+Other releases will typically be maintained on a best effort basis which typically means until the next stable release is out.
 -->
 他のリリースは、一般的に次の stable リリースが出るまでを指すベストエフォートの原則で、一般的にはメンテナンスされるでしょう。
 
@@ -99,8 +90,6 @@ LXC 4.0、3.0 は長期サポート版のリリースです。
  - LXC 3.0 は 2023 年 6 月 1 日までサポートされます
 
 <!--
-This is thanks to [Canonical Ltd](http://www.canonical.com) and Ubuntu who include
-the long term support releases of LXC into their own LTS releases and work closely
-with LXC upstream to maintain our stable branches.
+This is thanks to [Canonical Ltd](http://www.canonical.com) and Ubuntu who include the long term support releases of LXC into their own LTS releases and work closely with LXC upstream to maintain our stable branches.
 -->
 これは、[Canonical Ltd](http://www.canonical.com) と Ubuntu が LTS (長期サポート版) に LXC の LTS を含めているためであり、stable ブランチをメンテナンスするために LXC の開発元と密接に連携しているためです。

--- a/content/lxc/security.ja.md
+++ b/content/lxc/security.ja.md
@@ -8,39 +8,29 @@ LXC コンテナは以下のような 2 種類の構成を取ることができ�
  - 非特権コンテナ <!-- Unprivileged containers -->
 
 <!--
-The former can be thought as old-style containers, they're not safe at all and should only be used
-in environments where unprivileged containers aren't available and where you would trust
-your container's user with root access to the host.
+The former can be thought as old-style containers, they're not safe at all and should only be used in environments where unprivileged containers aren't available and where you would trust your container's user with root access to the host.
 -->
 特権コンテナは以前から存在するスタイルのコンテナと考えることができます。特権コンテナは全く安全ではありません。この種類のコンテナは非特権コンテナが利用できない場合で、ホストに対して root 権限を与えることになるコンテナユーザを信頼できる場合にのみ使うべきです。
 
 <!--
-The latter has been introduced back in LXC 1.0 (February 2014) and requires a reasonably recent
-kernel (3.13 or higher). The upside being that we do consider those containers to be root-safe and so,
-as long as you keep on top of kernel security issues, those containers are safe.
+The latter has been introduced back in LXC 1.0 (February 2014) and requires a reasonably recent kernel (3.13 or higher). The upside being that we do consider those containers to be root-safe and so, as long as you keep on top of kernel security issues, those containers are safe.
 -->
 非特権コンテナは LXC 1.0 (2014 年 2 月リリース) で導入されました。非特権コンテナにはかなり最近のカーネル (3.13 以上) が必要です。非特権コンテナの利点は、コンテナは root 権限を使った攻撃に対して安全であると考えられるので、カーネルのセキュリティ問題に対処している限りは、コンテナは安全であるということです。
 
 <!--
-As privileged containers are considered unsafe, we typically will not consider new container escape
-exploits to be security issues worthy of a CVE and quick fix. We will however try to mitigate those
-issues so that accidental damage to the host is prevented.
+As privileged containers are considered unsafe, we typically will not consider new container escape exploits to be security issues worthy of a CVE and quick fix. We will however try to mitigate those issues so that accidental damage to the host is prevented.
 -->
 特権コンテナは安全ではないと見なせるので、一般的にはコンテナは CVE や迅速な修正が必要なセキュリティ上の問題を悪用することからは逃れられないでしょう。しかし、私たちはホストを予期しないダメージから守るために、このような問題の影響を軽減するようにします。
 
 # 特権コンテナ <!-- Privileged containers -->
 <!--
-Privileged containers are defined as any container where the container uid 0 is mapped to the host's uid 0.
-In such containers, protection of the host and prevention of escape is entirely done through
-Mandatory Access Control (apparmor, selinux), seccomp filters, dropping of capabilities and namespaces.
+Privileged containers are defined as any container where the container uid 0 is mapped to the host's uid 0. In such containers, protection of the host and prevention of escape is entirely done through Mandatory Access Control (apparmor, selinux), seccomp filters, dropping of capabilities and namespaces.
 -->
 特権コンテナは、コンテナの uid 0 がホストの uid 0 にマッピングされるコンテナとして定義されます。
 このようなコンテナでは、ホストの保護とコンテナからの脱出の防止は、強制アクセス制御 (apparmor, selinux)、seccomp フィルタ、ケーパビリティの削除、名前空間の利用を通して行います。
 
 <!--
-Those technologies combined will typically prevent any accidental damage of the host,
-where damage is defined as things like reconfiguring host hardware,
-reconfiguring the host kernel or accessing the host filesystem.
+Those technologies combined will typically prevent any accidental damage of the host, where damage is defined as things like reconfiguring host hardware, reconfiguring the host kernel or accessing the host filesystem.
 -->
 以上の技術の組み合わせは、主にホストに対する予期しないダメージを防ぐでしょう。ここで言うダメージとは、ホストのハードウェアやホストカーネルの再設定、ホストのファイルシステムへのアクセスのような行為です。
 
@@ -50,15 +40,12 @@ LXC upstream's position is that those containers aren't and cannot be root-safe.
 LXC 開発者は、このようなコンテナは root 権限を使った攻撃に対して脆弱であり、安全にはできないという見解を取っています。
 
 <!--
-They are still valuable in an environment where you are running trusted workloads
-or where no untrusted task is running as root in the container.
+They are still valuable in an environment where you are running trusted workloads or where no untrusted task is running as root in the container.
 -->
 特権コンテナは、信頼できる作業を実行するような環境や、コンテナ内で root 権限で信用できないタスクが実行されていない環境では今でも役に立ちます。
 
 <!--
-We are aware of a number of exploits which will let you escape such containers and get full root privileges on the host.
-Some of those exploits can be trivially blocked and so we do update our different policies once made aware of them.
-Some others aren't blockable as they would require blocking so many core features that the average container would become completely unusable.
+We are aware of a number of exploits which will let you escape such containers and get full root privileges on the host. Some of those exploits can be trivially blocked and so we do update our different policies once made aware of them. Some others aren't blockable as they would require blocking so many core features that the average container would become completely unusable.
 -->
 私たちは、このようなコンテナから抜け出し、ホスト上で root 権限を全て取得するような多数の exploit を知っています。
 これらの exploit には普通にブロックできるものもありますので、それがわかった時点でそれまでとは異なったポリシーに更新します。
@@ -66,15 +53,12 @@ Some others aren't blockable as they would require blocking so many core feature
 
 # 非特権コンテナ <!-- Unprivileged containers -->
 <!--
-Unprivileged containers are safe by design. The container uid 0 is mapped to an unprivileged user outside of the container
-and only has extra rights on resources that it owns itself.
+Unprivileged containers are safe by design. The container uid 0 is mapped to an unprivileged user outside of the container and only has extra rights on resources that it owns itself.
 -->
 非特権コンテナは仕様上安全です。コンテナの uid 0 はコンテナ外では非特権ユーザにマッピングされます。そしてコンテナには自身が所有するリソースにのみ特権を持っています。
 
 <!--
-With such container, the use of SELinux, AppArmor, Seccomp and capabilities isn't necessary for security.
-LXC will still use those to add an extra layer of security which may be handy in the event
-of a kernel security issue but the security model isn't enforced by them.
+With such container, the use of SELinux, AppArmor, Seccomp and capabilities isn't necessary for security. LXC will still use those to add an extra layer of security which may be handy in the event of a kernel security issue but the security model isn't enforced by them.
 -->
 このようなコンテナでは、セキュリティ上の理由から SELinux, AppArmor, Seccomp, ケーパビリティを使う必要はありません。
 LXC は今でも以上の技術を使っています。これは万が一のカーネルのセキュリティ上の問題に対処できるセキュリティの追加レイヤーを加えるためです。この追加レイヤーは以上の技術によってセキュリティモデルを強制されません。
@@ -94,56 +78,45 @@ Everything else is run as your own user or as a uid which your user owns.
 これ以外はあなた自身のユーザで動作するか、あなたのユーザが所有する uid で動作します。
 
 <!--
-As a result, most security issues (container escape, resource abuse, ...) in those containers will apply just as well
-to a random unprivileged user and so would be a generic kernel security bug rather than a LXC issue.
+As a result, most security issues (container escape, resource abuse, ...) in those containers will apply just as well to a random unprivileged user and so would be a generic kernel security bug rather than a LXC issue.
 -->
 この結果、これらのコンテナの持つほとんどのセキュリティ上の問題 (コンテナからの脱出、リソースの悪用、...) はランダムな非特権ユーザに対して働きます。そのため、LXC の問題というよりは一般的なカーネルの問題になるでしょう。
 
 <!--
-LXC upstream is happy to help track such security issue and get in touch with the Linux kernel community
-to have them resolved as quickly as possible.
+LXC upstream is happy to help track such security issue and get in touch with the Linux kernel community to have them resolved as quickly as possible.
 -->
 LXC 開発者は喜んでこのようなセキュリティ上の問題を追跡することを手伝います。そして可能な限り早く問題を解決するために Linux カーネルコミュニティと連絡を取ります。
 
 # DoS 攻撃の可能性 <!-- Potential DoS attacks -->
 <!--
-LXC doesn't pretend to prevent DoS attacks by default. When running
-multiple untrusted containers or when allowing untrusted users to run
-containers, one should keep a few things in mind and update their
-configuration accordingly:
+LXC doesn't pretend to prevent DoS attacks by default. When running multiple untrusted containers or when allowing untrusted users to run containers, one should keep a few things in mind and update their configuration accordingly:
 -->
 LXC はデフォルトでは DoS 攻撃を防ぐことはありません。複数の信頼できないコンテナが実行中であったり、信頼できないユーザに対してコンテナの実行を許可している場合、いくつかの事項を考慮し、適切に設定を更新しておく必要があります:
 
 ## Cgroup による制限 <!-- Cgroup limits -->
 <!--
-LXC inherits cgroup limits from its parent, on my Linux distribution, there are no real limits set.
-As a result, a user in a container can reasonably easily DoS the host by running a fork bomb,
-by using all the system's memory or creating network interfaces until the kernel runs out of memory.
+LXC inherits cgroup limits from its parent, on my Linux distribution, there are no real limits set. As a result, a user in a container can reasonably easily DoS the host by running a fork bomb, by using all the system's memory or creating network interfaces until the kernel runs out of memory.
 -->
 LXC は cgroup による制限を親 cgroup から継承します。Linux ディストリビューションでは、実際には制限は設定されていません。その結果、コンテナ内のユーザが、fork bomb を実行したり、システムのメモリを全て使ったり、カーネルが out of memory になるまでネットワークインターフェースを作成したりすることで、簡単にホストに対して DoS 攻撃を実行できます。
 
 <!--
-This can be mitigated by either setting the relevant lxc.cgroup configuration entries (memory, cpu and pids)
-or by making sure that the parent user is placed in appropriately configured cgroups at login time.
+This can be mitigated by either setting the relevant lxc.cgroup configuration entries (memory, cpu and pids) or by making sure that the parent user is placed in appropriately configured cgroups at login time.
 -->
 これは、関係する lxc.cgroup エントリ (memory, cpu, pids) を設定したり、ログイン時に親となるユーザが適切に設定された cgroup 内に配置されるようにすることで軽減できます。
 
 ## ユーザに対する制限 <!-- User limits -->
 <!--
-As with cgroups, the parent's limit is inherited so unprivileged containers cannot have ulimits set to values
-higher than their parent.
+As with cgroups, the parent's limit is inherited so unprivileged containers cannot have ulimits set to values higher than their parent.
 -->
 cgroup のように親の制限が継承されるので、非特権コンテナは親よりも高い値の ulimits を設定できません。
 
 <!--
-However there is one thing that's worth keeping in mind, ulimits are as their name suggest, tied to a uid at the kernel level.
-That's a global kernel uid, not a uid inside a user namespace.
+However there is one thing that's worth keeping in mind, ulimits are as their name suggest, tied to a uid at the kernel level. That's a global kernel uid, not a uid inside a user namespace.
 -->
 しかし、覚えておくべきことがひとつあります。ulimit は名前が表すように、カーネルレベルで uid と結びついています。これはグローバルのカーネル uid であり、ユーザ名前空間内の uid ではありません。
 
 <!--
-That means that if two containers share through identical or overlapping id maps, a common kernel uid, then they also share limits,
-meaning that a user in a first container can effectively DoS the same user in another container.
+That means that if two containers share through identical or overlapping id maps, a common kernel uid, then they also share limits, meaning that a user in a first container can effectively DoS the same user in another container.
 -->
 もし 2 つのコンテナが同一か重複する id のマッピングで、共通のカーネル uid を共有している場合、制限も共有するということを意味します。そして、あるコンテナ内のユーザは他のコンテナの同じユーザに DoS 攻撃を加えることができることを意味します。
 
@@ -164,37 +137,25 @@ As a container connected to a bridge can transmit any level 2 traffic that it wi
 ブリッジに接続するコンテナは、通信したいどんなレイヤー 2 のトラフィックでも送信できるので、ブリッジ上で MAC アドレスや IP アドレスのスプーフィングを行えます。
 
 <!--
-When running untrusted containers or when allowing untrusted users to run containers, one should ideally create one bridge per user or per
-group of untrusted containers and configure /etc/lxc/lxc-usernet such that users may only use the bridges that they have been allocated.
+When running untrusted containers or when allowing untrusted users to run containers, one should ideally create one bridge per user or per group of untrusted containers and configure /etc/lxc/lxc-usernet such that users may only use the bridges that they have been allocated.
 -->
 信頼できないコンテナが実行されていたり、信頼できないユーザにコンテナの実行を許可している場合、理想的には信頼できないコンテナのユーザもしくはグループごとにひとつブリッジを作成すべきです。そして、ユーザに対して割り当てられたブリッジだけを使えるように /etc/lxc/lxc-usernet を設定すべきです。
 
 ### IPv6 ルータ広告の受け入れをセキュアにする <!-- Securing IPv6 Router Advertisements acceptance -->
 
 <!--
-In addition to this, one must take care to consider the possibility of containers modifying the LXC host's IPv6
-routing table through IPv6 router advertisements. This is because the default LXC bridge is configured with
-IPv4 addresses only. This means that the value of `/proc/sys/net/ipv6/conf/default/accept_ra` is applied to the
-lxcbr0 interface. If it is a value > 0 then the LXC host will accept (potentially malicious) router advertisements
-from the containers connected to the bridge.
+In addition to this, one must take care to consider the possibility of containers modifying the LXC host's IPv6 routing table through IPv6 router advertisements. This is because the default LXC bridge is configured with IPv4 addresses only. This means that the value of `/proc/sys/net/ipv6/conf/default/accept_ra` is applied to the lxcbr0 interface. If it is a value > 0 then the LXC host will accept (potentially malicious) router advertisements from the containers connected to the bridge.
 -->
 これに加えて、コンテナが IPv6 のルータ広告（Router Advertisement）を通して LXC ホストの IPv6 ルーティングテーブルを変更する可能性を考慮しておかなければなりません。これは、デフォルトの LXC のブリッジが IPv4 のみで構成されているからです。これは `/proc/sys/net/ipv6/conf/default/accept_ra` の値が lxcbr0 インターフェースに対しても適用されるということです。この値が 0 より大きな場合、LXC ホストはブリッジに接続されたコンテナからの（悪意がある可能性がある）ルータ広告を受け入れます。
 
 <!--
-To avoid this you can either configure IPv6 addresses on the default bridge by setting the `LXC_IPV6_*` variables
-in `/etc/default/lxc-net` (this will enable `/proc/sys/net/ipv6/conf/lxcbr0/forwarding` which causes
-`/proc/sys/net/ipv6/conf/lxcbr0/accept_ra` to be effectively disabled if the value is `1`. See
-https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt for more info), or you can set the
-`/proc/sys/net/ipv6/conf/default/accept_ra` setting to `0` so that when `lxcbr0` is created it's `accept_ra` is
-disabled. However if you are using IPv6 on the LXC host and relying on router advertisements from the external
-network then you should ensure that `accept_ra` is enabled for the external interface to avoid losing connectivity.
+To avoid this you can either configure IPv6 addresses on the default bridge by setting the `LXC_IPV6_*` variables in `/etc/default/lxc-net` (this will enable `/proc/sys/net/ipv6/conf/lxcbr0/forwarding` which causes `/proc/sys/net/ipv6/conf/lxcbr0/accept_ra` to be effectively disabled if the value is `1`. See https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt for more info), or you can set the `/proc/sys/net/ipv6/conf/default/accept_ra` setting to `0` so that when `lxcbr0` is created it's `accept_ra` is disabled. However if you are using IPv6 on the LXC host and relying on router advertisements from the external network then you should ensure that `accept_ra` is enabled for the external interface to avoid losing connectivity.
 -->
 これを防ぐため、`/etc/default/lxc-net` ファイルで `LXC_IPV6_*` 変数を設定することで、デフォルトブリッジ上での IPv6 アドレスを設定できます（これは `/proc/sys/net/ipv6/conf/lxcbr0/forwarding` を有効にします。このファイルの値が 1 の場合は、`/proc/sys/net/ipv6/conf/lxcbr0/accept_ra` を事実上無効化します。詳しくは https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt をご覧ください）。もしくは、`lxcbr0` が作成された時に `accept_ra` が無効になるように、`/proc/sys/net/ipv6/conf/default/accept_ra` を `0` に設定することもできます。しかし、もし LXC ホストで IPv6 を使っており、外部ネットワークからのルータ広告に依存しているのであれば、外部との接続が失われるのを防ぐために、外部インターフェースで確実に `accept_ra` が有効になっているようにすべきです。
 
 # セキュリティ上の問題の報告 <!-- Reporting security issues -->
 <!--
-To ensure security issues can be fixed as quickly as possible and simultaneously
-in all Linux distributions, issues should be reported either:
+To ensure security issues can be fixed as quickly as possible and simultaneously in all Linux distributions, issues should be reported either:
 -->
 セキュリティ上の問題ができるだけ素早く同時に全ての Linux ディストリビューションで解決するように、問題は以下のどちらかの方法で報告してください:
 
@@ -202,8 +163,6 @@ in all Linux distributions, issues should be reported either:
  * <!-- By opening a private security bug at --> [https://launchpad.net/ubuntu/+source/lxc/+filebug](https://launchpad.net/ubuntu/+source/lxc/+filebug) に非公開のセキュリティバグをオープンする
 
 <!--
-We will then confirm the security issue, come up with fixes against all supported releases,
-provide you those patches for testing and then get a CVE assigned as well as a
-coordinated release date for you and the Linux distribution community.
+We will then confirm the security issue, come up with fixes against all supported releases, provide you those patches for testing and then get a CVE assigned as well as a coordinated release date for you and the Linux distribution community.
 -->
 私たちはセキュリティ上の問題を確認し、すべてのサポート中のリリースに対する修正を準備します。そして、テスト用にあなたにパッチを準備し、CVE 番号の割り当てを取得し、あなたと Linux ディストリビューションコミュニティに対して調整したリリース日を提供します。

--- a/content/lxcfs/contribute.ja.md
+++ b/content/lxcfs/contribute.ja.md
@@ -7,8 +7,7 @@ LXCFS の最新の開発バージョンは GitHub からクローンできます
     git clone git://github.com/lxc/lxcfs
 
 <!--
-Contributions sent upstream for review must be based on the current git tree
-and not on stable releases, unless the bug only affects a stable release.
+Contributions sent upstream for review must be based on the current git tree and not on stable releases, unless the bug only affects a stable release.
 -->
 レビューのためにパッチを送る場合は、バグが stable リリースにのみ影響する場合を除いて、stable リリースでなく現時点の開発バージョンのツリーを元にしてください。
 

--- a/content/lxcfs/downloads.ja.md
+++ b/content/lxcfs/downloads.ja.md
@@ -1,14 +1,12 @@
 
 # ディストリビューションのパッケージ <!-- Distribution packages -->
 <!--
-LXCFS is included in many Linux distributions.
-In most cases installing it is as simple as selecting it in your package manager.
+LXCFS is included in many Linux distributions. In most cases installing it is as simple as selecting it in your package manager.
 -->
 LXCFS はたくさんのディストリビューションに含まれています。ほとんどの場合、インストールするには、お使いのパッケージマネージャで LXCFS を選択するだけで簡単です。
 
 <!--
-Distributions also often provide backports of newer versions of LXCFS for their stable releases.
-You may want to look for that, especially if your distribution doesn't include LXCFS at all or not the new 4.0 branch.
+Distributions also often provide backports of newer versions of LXCFS for their stable releases. You may want to look for that, especially if your distribution doesn't include LXCFS at all or not the new 4.0 branch.
 -->
 ディストリビューションでは、stable リリース向けに新しいバージョンの LXCFS のバックポートを提供することがよくあります。特に、お使いのディストリビューションに LXCFS が含まれていない場合や、新しい 4.0 ブランチでない場合には、探してみる必要があるかもしれません。
 

--- a/content/lxcfs/introduction.ja.md
+++ b/content/lxcfs/introduction.ja.md
@@ -19,15 +19,12 @@ The code is pretty simple, written in C using libfuse.
 コードはとてもシンプルで、libfuse を使って C 言語で書かれています。
 
 <!--
-The main driver for this work was the need to run systemd based containers as a regular unprivileged user
-while still allowing systemd inside the container to interact with cgroups.
+The main driver for this work was the need to run systemd based containers as a regular unprivileged user while still allowing systemd inside the container to interact with cgroups.
 -->
 この動作を行うメインのドライバーは、コンテナ内の systemd が cgroup を扱いながら、通常の非特権ユーザが systemd ベースのコンテナを実行するのに必要でした。
 
 <!--
-Now with the introduction of the cgroup namespace in the Linux kernel, that part is no longer necessary
-on recent kernels and focus is now on making containers feel more like a real independent system through
-the proc masking feature.
+Now with the introduction of the cgroup namespace in the Linux kernel, that part is no longer necessary on recent kernels and focus is now on making containers feel more like a real independent system through the proc masking feature.
 -->
 Linux カーネルへの cgroup namespace の導入により、この機能は新しいカーネルでは不要になりました。そして、proc をマスキングする機能により、コンテナを本当の独立したシステムを使っているように見せる機能にフォーカスを当てています。(訳注: vanilla kernel であれば 4.6 以上、Ubuntu であれば 4.4 以上のカーネルで cgroup namespace が使えます。)
 

--- a/content/lxd/contribute.ja.md
+++ b/content/lxd/contribute.ja.md
@@ -8,8 +8,7 @@ LXD の現時点の開発バージョンは GitHub からクローンできま�
     git clone git://github.com/lxc/lxd
 
 <!--
-Contributions sent upstream for review must be based on the current git tree
-and not on stable releases, unless the bug only affects a stable release.
+Contributions sent upstream for review must be based on the current git tree and not on stable releases, unless the bug only affects a stable release.
 -->
 レビューのためにパッチを送る場合は、バグが stable リリースにのみ影響する場合を除いて、stable リリースでなく現時点の開発バージョンのツリーを元にしてください。
 
@@ -27,8 +26,7 @@ More details on contribution guidelines may be found [here](https://github.com/l
 # 安定版 (stable) リリースへのバックポート <!-- Stable release backports -->
 
 <!--
-In general, all bugfixes will be picked up for the stable release, this however tends to happen in batches
-every couple of months or so. If we missed a given patch, please file a bug so we can look into it.
+In general, all bugfixes will be picked up for the stable release, this however tends to happen in batches every couple of months or so. If we missed a given patch, please file a bug so we can look into it.
 -->
 一般的には、すべてのバグ修正が安定版リリースに対して適用されます。しかし、この適用は 2〜3 ヶ月程度おきになりがちです。もし、パッチを見逃しているような場合は、調査ができるようにバグ報告をしてください。
 

--- a/content/lxd/downloads.ja.md
+++ b/content/lxd/downloads.ja.md
@@ -1,9 +1,12 @@
 # ディストリビューションのパッケージ <!-- Distribution packages -->
 <!--
 LXD is shipped by a number of Linux distributions.
-Installation instructions can be found in our [getting started](/lxd/getting-started-cli/) guide.
 -->
 LXD はたくさんのディストリビューションに含まれています。
+
+<!--
+Installation instructions can be found in our [getting started](/lxd/getting-started-cli/) guide.
+-->
 インストール方法については [はじめに](/ja/lxd/getting-started-cli/) のページをご覧ください。
 
 # 現時点の開発バージョン <!-- Current development version -->

--- a/content/lxd/getting-started-cli.ja.md
+++ b/content/lxd/getting-started-cli.ja.md
@@ -12,8 +12,7 @@ LXD では 3 つのリリースブランチが並行してメンテナンスさ�
  * フィーチャーリリース: <!-- Feature releases: -->LXD 4.x
 
 <!--
-LTS releases are recommended for production environments as they will benefit from regular bugfix
-and security updates but will not see new features added or any kind of behavioral change.
+LTS releases are recommended for production environments as they will benefit from regular bugfix and security updates but will not see new features added or any kind of behavioral change.
 -->
 LTS リリースは本番環境での使用におすすめです。定期的なバグフィックスとセキュリティアップデートが行われますが、新しい機能の追加や動作が変わるような変更は行われないためです。
 

--- a/content/lxd/rest-api.ja.md
+++ b/content/lxd/rest-api.ja.md
@@ -8,11 +8,9 @@ LXD currently only implements a single version of the API, called "1.0".
 LXD では、現時点で "1.0" と呼ばれる単一のバージョンの API のみが実装されています。
 
 <!--
-Details on that API can be found at:
-[https://github.com/lxc/lxd/blob/master/doc/rest-api.md](https://github.com/lxc/lxd/blob/master/doc/rest-api.md)
+An interactive version of the API documentation can be [found here](https://linuxcontainers.org/lxd/api/master/). And some more general information about the API can be [found here](https://linuxcontainers.org/lxd/docs/master/rest-api).
 -->
-API の詳細は以下でご覧いただけます:
-[https://github.com/lxc/lxd/blob/master/doc/rest-api.md](https://github.com/lxc/lxd/blob/master/doc/rest-api.md)
+API ドキュメントのインタラクティブバージョンは[こちら]((https://linuxcontainers.org/lxd/api/master/)でご覧いただけます。そして API に関するもっと一般的な情報は[こちら](https://linuxcontainers.org/lxd/docs/master/rest-api)にあります。
 
 ## API の後方互換性 <!-- API backward compatibility -->
 


### PR DESCRIPTION
* Update Japanese "The LXD API" page
* In this commit, many Japanese file is updated, but Japanese contents is not updated. We just removed line breaks in commented English lines. Because if the Japanese page is not updated after English version, "the page is out of date" will be displayed in Japanese pages. In #540 , many line breaks in English pages have been removed while contents remain the same.