### PR TITLE
lxd: update links

### DIFF
--- a/content/lxd/contribute.md
+++ b/content/lxd/contribute.md
@@ -10,7 +10,7 @@ Contributions sent upstream for review must be based on the current git tree and
 
 Contributions to LXD must be submitted as GitHub pull-requests and we require them to be signed-off.
 
-More details on contribution guidelines may be found [here](https://linuxcontainers.org/lxd/docs/master/contributing)
+More details on contribution guidelines can be found [here](https://linuxcontainers.org/lxd/docs/latest/contributing).
 
 # Stable release backports
 

--- a/content/lxd/downloads.md
+++ b/content/lxd/downloads.md
@@ -8,9 +8,9 @@ You can clone LXD directly with:
 
     git clone https://github.com/lxc/lxd
 
-For Building instructions, see the [LXD Documentation](https://linuxcontainers.org/lxd/docs/master/#installing-lxd-from-source).
+For Building instructions, see the [LXD Documentation](https://linuxcontainers.org/lxd/docs/latest/installing/#installing-lxd-from-source).
 
 # Release tarballs
 Stable release tarballs are available for download below.
 
-For Building instructions, see the [LXD Documentation](https://linuxcontainers.org/lxd/docs/master/#installing-lxd-from-source).
+For Building instructions, see the [LXD Documentation](https://linuxcontainers.org/lxd/docs/latest/installing/#installing-lxd-from-source).

--- a/content/lxd/introduction.md
+++ b/content/lxd/introduction.md
@@ -70,9 +70,9 @@ Backup and export
   * [Live migration](https://linuxcontainers.org/lxd/docs/master/migration) (using CRIU)
 
 Configurability
-: * [Multiple storage backends](https://linuxcontainers.org/lxd/docs/master/storage) (with configurable storage pools and storage volumes)
-  * [Network management](https://linuxcontainers.org/lxd/docs/master/networks) (including bridge creation and configuration, cross-host tunnels, ...)
-  * [Advanced resource control](https://linuxcontainers.org/lxd/docs/master/instances#resource-limits-via-) (CPU, memory, network I/O, block I/O, disk usage and kernel resources)
+: * [Multiple storage backends](https://linuxcontainers.org/lxd/docs/master/explanation/storage/) (with configurable storage pools and storage volumes)
+  * [Network management](https://linuxcontainers.org/lxd/docs/master/explanation/networks/) (including bridge creation and configuration, cross-host tunnels, ...)
+  * [Advanced resource control](https://linuxcontainers.org/lxd/docs/master/instances/#resource-limits-via-limits-kernel-limit-name) (CPU, memory, network I/O, block I/O, disk usage and kernel resources)
   * [Device passthrough](https://linuxcontainers.org/lxd/docs/master/container-environment) (USB, GPU, unix character and block devices, NICs, disks and paths)
 
 
@@ -115,7 +115,7 @@ LXD is written in Go. It is free software and developed under the [Apache 2 lice
 
 The LXD source code is available on [GitHub](https://github.com/lxc/lxd).
 
-There are no CLA or similar legal agreements required to contribute to LXD. However, we require commits be signed-off (following the DCO - Developer Certificate of Ownership). See the [Contribution guidelines](https://github.com/lxc/lxd/blob/master/doc/contributing.md) for more information.
+There are no CLA or similar legal agreements required to contribute to LXD. However, we require commits be signed-off (following the DCO - Developer Certificate of Ownership). See the [Contribution guidelines](https://linuxcontainers.org/lxd/docs/latest/contributing/) for more information.
 
 [<img src="/static/img/GitHub_Logo.png" alt="GitHub logo" style="display:block;float:none;margin-left:auto;margin-right:auto;padding:1em 0;max-height:120px"/>](https://github.com/lxc/lxd)
 


### PR DESCRIPTION
Update some of the documentation links to more suitable/precise
targets.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>