### PR TITLE
Update Navigation with vanilla framework 3.7.1

### DIFF
--- a/content/index.ja.html
+++ b/content/index.ja.html
@@ -188,7 +188,7 @@
         CGManager は cgroup を管理するデーモンです。DBus API を通して、ネストした非特権コンテナであっても、コンテナを作成してそのコンテナの cgroup を管理できるように設計されています。
       </p>
 
-      <p><a class="btn btn-primary" href="/ja/cgmanager/introduction/" role="button">詳しく見る</a></p>
+      <p><a class="p-button--positive" href="/ja/cgmanager/introduction/" role="button">詳しく見る</a></p>
     </div>
   </div>
 </div>

--- a/content/lxd/try-it.html
+++ b/content/lxd/try-it.html
@@ -11,7 +11,7 @@
     <div class="col-12">
       <noscript>
         <div class="p-notification--negative">
-          <div class="p-notification__response">
+          <div class="p-card__content">
             <span class="p-notification__status">JavaScript required: </span>
             <p>The LXD demo service client is entirely JavaScript based.</p>
             <p>It appears the your web browser doesn't support JavaScript or that you or an extension you installed is disabling JavaScript for this site.</p>
@@ -20,9 +20,9 @@
         </div>
       </noscript>
 
-      <div class="p-notification--information" id="tryit_status_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">Server status</h2>
+      <div class="p-card" id="tryit_status_panel" style="display:none">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">Server status</h2>
           <span class="p-notification__body" id="tryit_online_message" style="display:none">You are connected over: <span id="tryit_protocol"></span> (<span id="tryit_address"></span>)<br/>The demo server is currently running <span id="tryit_count"></span> user sessions out of <span id="tryit_max"></span>.</span>
 
           <span class="p-notification__body" id="tryit_maintenance_message" style="display:none">The demo service is currently down for maintenance and should be back online in a few minutes.</span>
@@ -31,31 +31,31 @@
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_terms_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">Terms of service</h2>
+      <div class="p-card" id="tryit_terms_panel" style="display:none">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">Terms of service</h2>
           <span id="tryit_terms"></span>
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_start_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">Start</h2>
+      <div class="p-card" id="tryit_start_panel" style="display:none">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">Start</h2>
           <div id="tryit_accept_terms">
             <input type="checkbox" value="" id="tryit_terms_checkbox" />
             <label for="tryit_terms_checkbox">
              I have read and I accept the terms of service above.
             </label>
-            <button type="submit" id="tryit_accept" class="btn btn-primary" disabled="">Start</button>
+            <button type="submit" id="tryit_accept" class="p-button--positive" disabled="">Start</button>
           </div>
           <div id="tryit_progress" style="display:none;width:100%;text-align:center;">
-            <p class="p-heading--four">Starting the container <i class="p-icon--spinner u-animation--spin"></i></p>
+            <p class="p-heading--4">Starting the container <i class="p-icon--spinner u-animation--spin"></i></p>
           </div>
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_examples_panel" style="display:none">
-        <div class="p-notification__response">
+      <div class="p-card" id="tryit_examples_panel" style="display:none">
+        <div class="p-card__content">
           <span class="p-notification__status js-collapsable">Step by step instructions</span>
 
           <ol id="tryit_navigation" style="display:none">
@@ -83,7 +83,7 @@
             <nav aria-label="...">
               <ul class="p-inline-list u-align--center u-no-margin--bottom">
                 <li class="p-inline-list__item">
-                  <a class="p-button is--disabled u-no-margin--bottom" aria-disabled="true">Previous</a>
+                  <a class="p-button is-disabled u-no-margin--bottom" aria-disabled="true">Previous</a>
                 </li>
                 <li class="p-inline-list__item">
                   <a class="p-button js-tab-button tabNext u-no-margin--bottom tryit_goto">Next</a>
@@ -361,7 +361,7 @@ exit</pre>
                   <a class="p-button js-tab-button tabPrevious u-no-margin--bottom tryit_goto">Previous</a>
                 </li>
                 <li class="p-inline-list__item">
-                  <a class="p-button is--disabled u-no-margin--bottom" aria-disabled="true">Next</a>
+                  <a class="p-button is-disabled u-no-margin--bottom" aria-disabled="true">Next</a>
                 </li>
               </ul>
             </nav>
@@ -369,8 +369,8 @@ exit</pre>
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_feedback" style="display:none">
-        <div class="p-notification__response">
+      <div class="p-card" id="tryit_feedback" style="display:none">
+        <div class="p-card__content">
           <span class="p-notification__status js-collapsable">Feedback</span>
           <div class="panel-body">
             <form class="p-form" id="tryit_feedback_submit">
@@ -428,12 +428,12 @@ exit</pre>
   </div>
 </div>
 
-<div class="row" id="tryit_console_row" style="display:none">
-  <div class="col-12">
+<div id="tryit_console_row" style="display:none">
+  <div class="row">
     <hr/>
-    <div class="p-notification" id="tryit_console_panel">
-      <div class="p-notification__response">
-        <h2 class="p-heading--four">Terminal (<span class="minutes"></span> minutes, <span class="seconds"></span> seconds remaining)</h2>
+    <div class="p-card" id="tryit_console_panel">
+      <div class="p-card__content">
+        <h2 class="p-heading--4">Terminal (<span class="minutes"></span> minutes, <span class="seconds"></span> seconds remaining)</h2>
         <div style="padding-right: 1rem; overflow: auto; background-color: #000;">
           <div id="tryit_console" style="background-color:black;"></div>
         </div>

--- a/content/lxd/try-it.ja.html
+++ b/content/lxd/try-it.ja.html
@@ -8,9 +8,9 @@
 <div class="p-strip is-shallow" id="tryit-instructions">
   <div class="row">
     <div class="col-12">
-      <div class="p-notification--information" id="tryit_status_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">サーバの状態 <!-- Server status --></h2>
+      <div class="p-card" id="tryit_status_panel" style="display:none">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">サーバの状態 <!-- Server status --></h2>
           <span class="p-notification__body" id="tryit_online_message" style="display:none">接続元 <!-- You are connected over: --><span id="tryit_protocol"></span> (<span id="tryit_address"></span>)<<br/>
           デモサーバは現在ユーザセッションを <span id="tryit_count"></span> セッション実行中です (最大 <span id="tryit_max"></span> セッション中)<!-- The demo server is currently running <span id="tryit_count"></span> user sessions out of <span id="tryit_max"></span> --></span>
 
@@ -35,32 +35,32 @@
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_terms_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">サービス利用規約 <!-- Terms of service --></h2>
+      <div class="p-card" id="tryit_terms_panel" style="display:none">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">サービス利用規約 <!-- Terms of service --></h2>
           <span id="tryit_terms"></span>
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_start_panel" style="display:none">
-        <div class="p-notification__response">
-          <h2 class="p-heading--four">試用開始 <!-- Start --></h2>
+      <div class="p-card" id="tryit_start_panel" style="display:none">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">試用開始 <!-- Start --></h2>
           <div id="tryit_accept_terms">
             <input type="checkbox" value="" id="tryit_terms_checkbox" />
             <label for="tryit_terms_checkbox">
              私はサービス利用規約を読み、同意しました <!-- I have read and I accept the terms of service above -->
             </label>
-            <button type="submit" id="tryit_accept" class="btn btn-primary" disabled="">Start</button>
+            <button type="submit" id="tryit_accept" class="p-button--positive" disabled="">Start</button>
           </div>
           <div id="tryit_progress" style="display:none;width:100%;text-align:center;">
-            <p class="p-heading--four">コンテナの起動中... <!-- Starting the container... --> <i class="p-icon--spinner u-animation--spin"></i></p>
+            <p class="p-heading--4">コンテナの起動中... <!-- Starting the container... --> <i class="p-icon--spinner u-animation--spin"></i></p>
           </div>
         </div>
       </div>
 
 
-      <div class="p-notification--information" id="tryit_examples_panel" style="display:none">
-        <div class="p-notification__response">
+      <div class="p-card" id="tryit_examples_panel" style="display:none">
+        <div class="p-card__content">
           <span class="p-notification__status js-collapsable">ステップバイステップでの入門</span> <!-- Step by step introduction -->
 
           <ol id="tryit_navigation" style="display:none">
@@ -103,7 +103,7 @@
             <nav aria-label="...">
               <ul class="p-inline-list u-align--center">
                 <li class="p-inline-list__item">
-                  <a href="#" class="p-button is--disabled" aria-disabled="true">Previous</a>
+                  <a href="#" class="p-button is-disabled" aria-disabled="true">Previous</a>
                 </li>
                 <li class="p-inline-list__item">
                   <a href="#first-container" class="p-button js-tab-button tabNext tryit_goto">Next</a>
@@ -491,7 +491,7 @@ exit</pre>
                   <a href="#image-server" class="p-button js-tab-button tabPrevious tryit_goto">Previous</a>
                 </li>
                 <li class="p-inline-list__item">
-                  <a href="#conclusion" class="p-button is--disabled" aria-disabled="true">Next</a>
+                  <a href="#conclusion" class="p-button is-disabled" aria-disabled="true">Next</a>
                 </li>
               </ul>
             </nav>
@@ -499,8 +499,8 @@ exit</pre>
         </div>
       </div>
 
-      <div class="p-notification--information" id="tryit_feedback" style="display:none">
-        <div class="p-notification__response">
+      <div class="p-card" id="tryit_feedback" style="display:none">
+        <div class="p-card__content">
           <span class="p-notification__status js-collapsable">フィードバック<!-- Feedback --></span>
           <div class="panel-body">
             <form class="p-form" id="tryit_feedback_submit">
@@ -588,12 +588,12 @@ exit</pre>
   </div>
 </div>
 
-<div class="row" id="tryit_console_row" style="display:none">
-  <div class="col-12">
+<div id="tryit_console_row" style="display:none">
+  <div class="row">
     <hr/>
-    <div class="p-notification" id="tryit_console_panel">
-      <div class="p-notification__response">
-        <h2 class="p-heading--four">ターミナル <!-- Terminal -->(<span class="minutes"></span> 分<!-- minutes, --> <span class="seconds"></span> 秒<!-- seconds -->)</h2>
+    <div class="p-card" id="tryit_console_panel">
+      <div class="p-card__content">
+        <h2 class="p-heading--4">ターミナル <!-- Terminal -->(<span class="minutes"></span> 分<!-- minutes, --> <span class="seconds"></span> 秒<!-- seconds -->)</h2>
         <div style="padding-right: 1rem; overflow: auto; background-color: #000;">
           <div id="tryit_console" style="background-color:black;"></div>
         </div>

--- a/generate
+++ b/generate
@@ -96,25 +96,8 @@ def gen_menu(structure, override, prefix):
             continue
 
         if len(item['menu']) == 1:
-            if "generator" in item and item['generator'] == "manpages":
-                # Dynamic manpage menu
-                man_menu = []
-                man_path = item['meta']['dir'].lstrip("/")
-
-                for entry in sorted(os.listdir(man_path)):
-                    if not os.path.isfile("%s/%s" % (man_path, entry)):
-                        continue
-
-                    if entry.startswith("."):
-                        continue
-
-                    entry_link = "/%s/%s" % (item['path'].lstrip("/"), entry)
-                    man_menu.append((entry_link, entry))
-
-                menu.append((man_menu, item['menu'][0]))
-            else:
-                # Simple menu entry
-                menu.append((item['path'], item['menu'][0]))
+            # Simple menu entry
+            menu.append((item['path'], item['menu'][0]))
         else:
             # Drop-down menu
             if sub_menu_title != item['menu'][0]:
@@ -123,26 +106,8 @@ def gen_menu(structure, override, prefix):
                 sub_menu = []
                 sub_menu_title = item['menu'][0]
 
-            if "generator" in item and item['generator'] == "manpages":
-                # Dynamic manpage menu
-                man_menu = []
-                man_path = item['meta']['dir'].lstrip("/")
-
-                for entry in sorted(os.listdir(man_path)):
-                    if not os.path.isfile("%s/%s" % (man_path, entry)):
-                        continue
-
-                    if entry.startswith("."):
-                        continue
-
-                    entry_link = "/%s/man%s/%s.html" % (
-                        item['path'].lstrip("/"), entry.split(".")[-1], entry)
-                    man_menu.append((entry_link, entry))
-
-                sub_menu.append((man_menu, item['menu'][-1]))
-            else:
-                # Simple menu entry
-                sub_menu.append((item['path'], item['menu'][-1]))
+            # Simple menu entry
+            sub_menu.append((item['path'], item['menu'][-1]))
 
     # Process the last drop-down menu
     if structure and sub_menu_title:

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -90,6 +90,10 @@ p:empty {
 }
 
 /* Terminal */
+#tryit_accept {
+  display: block;
+}
+
 #tryit_console * {
   margin-top: 0;
   line-height: 1.5;
@@ -124,11 +128,6 @@ p:empty {
 /* Align text in notifications */
 [class^="p-notification"] {
   text-align: left;
-}
-
-/* Make the page width wider */
-.row {
-  max-width: 1170px;
 }
 
 /* Add spacing to pre tags */
@@ -195,93 +194,6 @@ pre code {
 
 #tryit_feedback .js-collapsable.is-hidden ~ .panel-body {
   display: none;
-}
-
-/* NAVIGATION */
-.p-navigation__logo {
-  font-size: 1.5rem;
-  line-height: 3rem;
-  padding: 0.2rem;
-}
-
-.p-navigation__logo img {
-  width: 45px;
-}
-
-.p-navigation__link {
-  position: relative;
-}
-
-.p-navigation__sub-links {
-  background-color: #fff;
-  opacity: 0;
-  padding: 0;
-  transition: all 0.5s ease;
-  z-index: 100;
-}
-
-.p-dropdown {
-  display: none;
-  margin: 0;
-  visibility: hidden;
-}
-
-@media (min-width: 769px) {
-  .p-navigation__sub-links {
-    border-color: #cdcdcd;
-    border-style: solid;
-    border-width: 0 1px 1px;
-    left: 0;
-    position: absolute;
-    width: 20rem;
-  }
-
-  .p-navigation__sub-links.is-split {
-    -moz-column-count: 2;
-    -moz-column-gap: 0;
-    -webkit-column-count: 2;
-    -webkit-column-gap: 0;
-    column-count: 2;
-    column-gap: 0;
-  }
-
-  .p-navigation__sub-links.is-split li {
-    -webkit-column-break-inside: avoid;
-    page-break-inside: avoid;
-    break-inside: avoid;
-  }
-
- .p-navigation__sub-links .p-navigation__sub-links {
-    border-width: 1px;
-    left: 19.875rem;
-    top: 0;
-  }
-}
-
-.p-dropdown__toggle {
-  position: relative;
-}
-
-.p-dropdown__toggle.is-active > .p-dropdown {
-  display: block;
-  opacity: 1;
-  visibility: visible;
-}
-
-.p-navigation__sub-link {
-  display: block;
-  font-size: .875rem;
-  padding: .5rem 1rem;
-}
-
-@media (max-width: 768px) {
-  .p-navigation__sub-link {
-    padding: .5rem 1.5rem;
-  }
-}
-
-.p-navigation__sub-link:not(.p-heading--five):hover {
-  background-color: #f7f7f7;
 }
 
 @media (min-width: 769px) {
@@ -409,6 +321,7 @@ iframe {
   background-color: #fff;
   border: 0;
   padding: .3375rem 1rem;
+  margin-bottom: 1px;
 }
 
 .tabbed-set label:hover {
@@ -438,4 +351,22 @@ iframe {
 /* add space below a details block */
 summary {
   margin-bottom: 2rem;
+}
+
+.p-navigation__image {
+  max-height: 2.5rem;
+}
+
+.p-breadcrumbs__items {
+  margin-bottom: 0.5rem;
+}
+
+.p-footer {
+  padding-bottom: 4rem;
+  padding-top: 4rem;
+}
+
+.p-footer {
+  border-top: 1px solid #cdcdcd;
+  position: relative;
 }

--- a/static/css/tryit.css
+++ b/static/css/tryit.css
@@ -12,7 +12,7 @@ div#tryit-instructions {
 }
 
 div#tryit_console_panel {
-    max-width: 1122px; /* 1170px from local.css - 2x24px padding */
+    width: 100%;
     margin-right: auto;
     margin-left: auto;
 }
@@ -29,7 +29,13 @@ div#tryit_info_panel table {
     width: 100%;
 }
 
+div#tryit_examples_panel pre,
+div#tryit_examples_panel h3 {
+    margin-bottom: 0;
+}
+
 div#tryit_examples_panel p {
+    margin-bottom: 0.5rem;
     max-width: 100%;
 }
 

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,82 +1,49 @@
-var dropdownToggles = document.querySelectorAll('.p-dropdown__toggle');
-var dropdownToggleLinks = document.querySelectorAll('.p-dropdown__toggle-link');
+function toggleDropdown(toggle, open) {
+  var parentElement = toggle.parentNode;
+  var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
+  dropdown.setAttribute('aria-hidden', !open);
 
-function isDescendant(parent, child) {
-  var node = child.parentNode;
-  while (node != null) {
-    if (node == parent) {
-      return true;
-    }
-    node = node.parentNode;
+  if (open) {
+    parentElement.classList.add('is-active');
+  } else {
+    parentElement.classList.remove('is-active');
   }
-  return false;
 }
 
-dropdownToggleLinks.forEach(function(dropdownToggleLink) {
-  dropdownToggleLink.addEventListener('click', function(event) {
-    event.preventDefault();
+function closeAllDropdowns(toggles) {
+  toggles.forEach(function (toggle) {
+    toggleDropdown(toggle, false);
   });
-});
+}
 
-dropdownToggles.forEach(function(dropdownToggle) {
-  dropdownToggle.addEventListener('click', function(event) {
-    event.stopPropagation();
+function handleClickOutside(toggles, containerClass) {
+  document.addEventListener('click', function (event) {
+    var target = event.target;
 
-    var clickedDropdown = this;
+    if (target.closest) {
+      if (!target.closest(containerClass)) {
+        closeAllDropdowns(toggles);
+      }
+    }
+  });
+}
 
-    dropdownToggles.forEach(function(dropdownToggle) {
-      var dropdownContent = document.getElementById(dropdownToggle.id + "-menu");
+function initNavDropdowns(containerClass) {
+  var toggles = [].slice.call(document.querySelectorAll(containerClass + ' [aria-controls]'));
 
-      if (dropdownToggle === clickedDropdown) {
-        if (dropdownToggle.classList.contains('is-active')) {
-          closeMenu(dropdownToggle, dropdownContent);
-        } else {
-          dropdownToggle.classList.add('is-active');
-          dropdownContent.classList.remove('u-hide');
+  handleClickOutside(toggles, containerClass);
 
-          if (window.history.pushState) {
-            window.history.pushState(null, null, '#' + dropdownToggle.id);
-          }
-        }
-      } else {
-        if (!isDescendant(dropdownContent, clickedDropdown)) {
-          dropdownToggle.classList.remove('is-active');
-          dropdownContent.classList.add('u-hide');
-        }
+  toggles.forEach(function (toggle) {
+    toggle.addEventListener('click', function (e) {
+      e.preventDefault();
+
+      const wasOpen = toggle.parentElement.classList.contains('is-active');
+      closeAllDropdowns(toggles);
+      if (!wasOpen) {
+        toggleDropdown(toggle, true);
       }
     });
   });
-});
-
-function closeMenu(dropdownToggle, dropdownContent) {
-  dropdownToggle.classList.remove('is-active');
-  if (window.history.pushState) {
-    window.history.pushState(null, null, window.location.href.split('#')[0]);
-  }
 }
 
-if (window.location.hash) {
-  var tabId = window.location.hash.split('#')[1];
-  var tab = document.getElementById(tabId);
-  var tabContent = document.getElementById(tabId + '-menu');
-
-  if (tab) {
-    setTimeout(function() {
-      document.getElementById(tabId).click();
-    }, 0);
-  }
-}
-
-function closeMainMenu() {
-  var navigationLinks = document.querySelectorAll('.p-dropdown__toggle');
-
-  navigationLinks.forEach(function(navLink) {
-    navLink.classList.remove('is-active');
-  });
-}
-
-document.addEventListener('click', function(event) {
-  if (!event.target.closest('.p-dropdown__link') && !event.target.closest('.p-dropdown__toggle a')) {
-    closeMainMenu();
-  }
-});
+initNavDropdowns('.p-navigation__item--dropdown-toggle')

--- a/static/js/tryit.js
+++ b/static/js/tryit.js
@@ -385,7 +385,7 @@ $(document).ready(function() {
              <div class='p-tab-buttons__list' id='tryit_progress'>";
 
         $('#tryit_navigation li').each(function(index) {
-            html += "<button class='p-tab-buttons__button' id='nav-"+this.getAttribute("name")+"'>";
+            html += "<button class='p-button is-dense' id='nav-"+this.getAttribute("name")+"'>";
             html += (index+1)+"</button>";
         });
 

--- a/templates/common/base.tpl.html
+++ b/templates/common/base.tpl.html
@@ -11,7 +11,7 @@
   {% else %}
   <title>Linux Containers</title>
   {% endif %}
-  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.8.0.min.css" />
+  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-3.8.0.min.css" />
   <link href="/static/css/local.css" rel="stylesheet"/>
   <link href="/static/css/pygments.css" rel="stylesheet"/>
 
@@ -33,7 +33,7 @@
 
   <section class="p-strip--light is-x-shallow">
     <div class="row">
-      <ul class="p-breadcrumbs u-no-margin--bottom">
+      <ul class="p-breadcrumbs__items">
         {% if page_menu %}
           {% for entry in page_menu %}
           <li class="p-breadcrumbs__item">{{ entry }}</li>

--- a/templates/common/footer.tpl.html
+++ b/templates/common/footer.tpl.html
@@ -1,7 +1,7 @@
 <footer class="p-footer">
-  <div class="row">
-    <p>Project sponsored by <a href="http://www.canonical.com">Canonical Ltd.</a></p>
-    <nav class="p-footer__nav">
+  <div class="p-footer--secondary row">
+    <p class="p-footer--secondary__content">Project sponsored by <a href="http://www.canonical.com">Canonical Ltd.</a></p>
+    <nav class="p-footer--secondary__nav">
       <ul class="p-inline-list--middot u-no-margin--bottom">
         <li class="p-inline-list__item">
           <a class="p-link--soft" href="https://github.com/lxc/linuxcontainers.org">Improve this website</a>

--- a/templates/common/header.tpl.html
+++ b/templates/common/header.tpl.html
@@ -1,9 +1,9 @@
 <header id="navigation" class="p-navigation">
-  <div class="row">
+  <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
-        <a class="p-navigation__link" href="/">
-         <img src="/static/img/containers.small.png" alt="Linux containers logo" border="0" />
+        <a class="p-navigation__item" href="/">
+         <img class="p-navigation__image" src="/static/img/containers.small.png" alt="Linux containers logo" border="0" />
         </a>
       </div>
       {% if menu %}
@@ -17,42 +17,29 @@
         <span class="u-off-screen">
           <a href="#main-content">Jump to main content</a>
         </span>
-        <ul class="p-navigation__links" role="menu">
+        <ul class="p-navigation__items" role="menu">
           {% for entry in menu %}
             {% if entry[0] is string %}
-              <li class="p-navigation__link{% if page_menu and page_menu[0] == entry[1] %} is-selected{% endif %}">
-                <a href="{{ entry[0] }}">{{ entry[1] }}</a>
+              <li class="p-navigation__item{% if page_menu and page_menu[0] == entry[1] %} is-selected{% endif %}">
+                <a href="{{ entry[0] }}" class="p-navigation__link">{{ entry[1] }}</a>
               </li>
             {% else %}
-              <li class="p-navigation__link p-dropdown__toggle {% if page_menu and page_menu[0] == entry[1] %} is-selected{% endif %}" id="{{ entry[1] }}">
-                <a href="#{{ entry[1] }}-menu" class="p-dropdown__toggle-link">{{ entry[1] }}</a>
-                <ul class="p-navigation__sub-links p-dropdown" id="{{ entry[1] }}-menu">
+              <li class="p-navigation__item--dropdown-toggle {% if page_menu and page_menu[0] == entry[1] %} is-selected{% endif %}" id="{{ entry[1] }}">
+                <a href="#{{ entry[1] }}-menu" class="p-navigation__link" aria-controls="{{ entry[1] }}-menu">{{ entry[1] }}</a>
+                <ul class="p-navigation__dropdown" id="{{ entry[1] }}-menu" aria-hidden="true">
                   {% for sub_entry in entry[0] %}
                     {% if not sub_entry[0] and sub_entry[0] is string %}
                       <!-- SEPARATOR / HEADING -->
                       <li>
                         <hr class="u-no-margin--bottom">
                         {% if sub_entry[1] %}
-                          <h3 class="p-heading--five p-navigation__sub-link u-no-margin--bottom">{{ sub_entry[1] }}</h3>
+                          <h3 class="p-heading--5 p-navigation__link u-no-margin--bottom">{{ sub_entry[1] }}</h3>
                         {% endif %}
                       </li>
                     {% else %}
-                      {% if sub_entry[0] is string %}
-                        <li>
-                          <a href="{{ sub_entry[0] }}"  class="p-navigation__sub-link{% if page_menu[1] == sub_entry[1] %} is-selected{% endif %} p-dropdown__link">{{ sub_entry[1] }}</a>
-                        </li>
-                      {% else %}
-                        <li class="p-dropdown__toggle" id="{{ entry[1] }}-{{ sub_entry[1] }}">
-                          <a class="p-navigation__sub-link{% if page_menu[1] == sub_entry[1] %} is-selected{% endif %} p-dropdown__toggle-link" href="#{{ entry[1] }}-{{ sub_entry[1] }}-menu">{{ sub_entry[1] }}</a>
-                          <ul class="p-navigation__sub-links p-dropdown is-split" id="{{ entry[1] }}-{{ sub_entry[1] }}-menu">
-                            {% for sub_sub_entry in sub_entry[0] %}
-                              <li>
-                                <a class="p-navigation__sub-link p-dropdown__link" href="{{ sub_sub_entry[0] }}">{{ sub_sub_entry[1] }}</a>
-                              </li>
-                            {% endfor %}
-                          </ul>
-                        </li>
-                      {% endif %}
+                      <li>
+                        <a href="{{ sub_entry[0] }}"  class="p-navigation__dropdown-item{% if page_menu[1] == sub_entry[1] %} is-selected{% endif %}">{{ sub_entry[1] }}</a>
+                      </li>
                     {% endif %}
                   {% endfor %}
                 </ul>
@@ -61,19 +48,19 @@
           {% endfor %}
         {% endif %}
       </ul>
-      <ul class="p-navigation__links p-language-switcher" role="menu">
+      <ul class="p-navigation__items" role="menu">
         {% if languages %}
-          <li class="p-navigation__link p-dropdown__toggle">
-            <a href="#languages" class="p-dropdown__toggle-link">{{ page_language[2] }}</a>
-            <ul class="p-navigation__sub-links p-dropdown" role="menu" id="languages">
+          <li class="p-navigation__item--dropdown-toggle">
+            <a href="#languages" class="p-navigation__link"aria-controls="languages">{{ page_language[2] }}</a>
+            <ul class="p-navigation__dropdown--right" role="menu" id="languages" aria-hidden="true">
               {% for language in languages %}
                 {% if page_language[0] == language[0] %}
-                  <li><a href="#" class="p-navigation__sub-link p-dropdown__link is-active">{{ language[1] }}</a></li>
+                  <li><a href="#" class="p-navigation__dropdown-item is-active">{{ language[1] }}</a></li>
                 {% else %}
                   {% if language[0] %}
-                    <li><a href="/{{ language[0] }}{{ page_raw_path }}"  class="p-navigation__sub-link p-dropdown__link">{{ language[1] }}</a></li>
+                    <li><a href="/{{ language[0] }}{{ page_raw_path }}"  class="p-navigation__dropdown-item">{{ language[1] }}</a></li>
                   {% else %}
-                    <li><a href="{{ page_raw_path }}"  class="p-navigation__sub-link p-dropdown__link">{{ language[1] }}</a></li>
+                    <li><a href="{{ page_raw_path }}"  class="p-navigation__dropdown-item">{{ language[1] }}</a></li>
                   {% endif %}
                 {% endif %}
               {% endfor %}

--- a/templates/markdown-page.tpl.html
+++ b/templates/markdown-page.tpl.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="row">
     <div class="p-strip">
-        <div class="col-12 u-wrap-content">
+        <div class="row">
             {{ content }}
         </div>
     </div>

--- a/templates/page.tpl.html
+++ b/templates/page.tpl.html
@@ -2,9 +2,7 @@
 {% block content %}
 <div class="p-strip">
     <div class="row">
-        <div class="col-12">
-            {{ content }}
-        </div>
+        {{ content }}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Using the latest and greatest Vanilla native navigation. It is a little different from current https://linuxcontainers.org/ mainly dropped the outlines and made it easier to read.

Further improvements with new vanilla effect boldness of menu, h2 and h3 text. Along with spacing refinements.

Do you agree and are you fine with the new styles (see images below)?

There are some open issues, which would require more work. I pause them because first want to know if the new styles are desired.

If the answer is yes, I'd invest more time to fix the remaining issues to make this mergeable. If not, the site could just stay with the old vanilla version, navigation, etc.

New menu closed

![new-vanilla-menu-closed](https://user-images.githubusercontent.com/1155472/192538685-6d3860d7-f8d9-4719-8566-179f837618f7.png)

New menu open

![new-vanilla-menu-open](https://user-images.githubusercontent.com/1155472/192539988-67cdd946-2332-4a32-a989-25eb64d3d35f.png)

Signed-off-by: David Edler <david.edler@canonical.com>