### PR TITLE
add a link checker and workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,25 @@
+name: Check links
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  push:
+  pull_request:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install linkchecker
+        run: sudo pip install LinkChecker
+
+      - name: Run linkchecker
+        run: linkchecker https://linuxcontainers.org/ -f .linkcheckerrc
+
+      - name: Print log
+        if: failure()
+        run: cat linkchecker-out.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ extensions/__pycache__
 .vscode
 .idea
 .venv
+linkchecker-out.txt

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,0 +1,9 @@
+[checking]
+maxrequestspersecond=5
+
+[filtering]
+nofollow=https\:\/\/linuxcontainers\.org\/lxd\/docs\/
+checkextern=1
+
+[output]
+fileoutput=text


### PR DESCRIPTION
Add a workflow that runs both on PRs and daily (because links might just randomly start failing) and checks for broken links.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>