### PR TITLE
fix some broken links in news

### DIFF
--- a/content/lxc/news.ja/lxc-3.0.0.yaml
+++ b/content/lxc/news.ja/lxc-3.0.0.yaml
@@ -52,8 +52,8 @@ content: |-
   The full list of deprecated keys and their new counterparts can be gathered from the [LXC 2.1 release announcement](https://discuss.linuxcontainers.org/t/lxc-2-1-has-been-released/487).
   -->
   LXC 3.0 以降、レガシーな設定項目はすべてサポートされません。
-  廃止された設定と、対応する新しい設定のすべてのリストは、[LXC 2.1 リリースのお知らせ](http://localhost/ja/lxc/news/#lxc-211-2017-10-19) を参照してください。
-  
+  廃止された設定と、対応する新しい設定のすべてのリストは、[LXC 2.1 リリースのお知らせ](https://linuxcontainers.org/ja/lxc/news/2017_09_05_00_00.html) を参照してください。
+
   <!--
   The `lxc-update-config` tool can be used to convert an older, now invalid, configuration to the new format.
   -->

--- a/content/lxc/news.ja/lxc-4.0.2.yaml
+++ b/content/lxc/news.ja/lxc-4.0.2.yaml
@@ -17,7 +17,7 @@ content: |-
   <!--
   This release fixes a number of issues that were reported shortly following the original [4.0.0](https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182) and [4.0.1](https://discuss.linuxcontainers.org/t/lxc-4-0-1-lts-has-been-released/7310) releases. Some of the highlights include:
   -->
-  このリリースでは、[4.0.0](/ja/lxc/news/#lxc-40-lts) と [4.0.1](ja/lxc/news/#lxc-401-lts) リリース後に報告された多数の問題を修正しています。主なものは次の通りです:
+  このリリースでは、[4.0.0](https://linuxcontainers.org/ja/lxc/news/2020_03_25_13_03.html) と [4.0.1](https://linuxcontainers.org/ja/lxc/news/2020_04_06_20_04.html) リリース後に報告された多数の問題を修正しています。主なものは次の通りです:
 
    - RISC-V 64bit サポート <!-- RISC-V 64bit support -->
    - `lxc-user-nic` でのより良いグループの扱い <!-- Better group handling in lxc-user-nic -->

--- a/content/lxc/news/lxc-1.0.7.yaml
+++ b/content/lxc/news/lxc-1.0.7.yaml
@@ -40,8 +40,8 @@ content: |-
    * fixed typo in comment
    * audit: added capacity and reserve() to nlmsg
    * rmdir and lxc\_unpriv returns non-negative error codes
-   * typofixes - https://github.com/vlajos/misspell\_fixer
-  
+   * typofixes - https://github.com/vlajos/misspell_fixer
+
   Bindings:
   
    * add src/python-lxc/setup.py into .gitignore

--- a/content/lxd/news/lxd-2.0.11.yaml
+++ b/content/lxd/news/lxd-2.0.11.yaml
@@ -8,7 +8,7 @@ content: |-
   Minor improvements:
 
    * LXD 2.0.11 is now snap aware and can be installed from the "2.0" track.
-   * The documentation is now available on ReadTheDocs: https://lxd.readthedocs.io/en/stable-2.0/
+   * The documentation is now available on ReadTheDocs
    * It's now possible to interrupt image downloads.
    * Added a new security.idmap.base config key (overrides the base uid/gid of the container).
    * Added support for delta image downloads.


### PR DESCRIPTION
These news exist only in the repo and not on Discourse - more broken links have been fixed on Discourse.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>