### PR TITLE
GitHub actions: cancel running link check

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,6 +6,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes sure we only run one concurrent link check (the link check runs on the published docs anyway, so there's no need to run more than one).