### PR TITLE
Update Vanilla framework to 4.1; change font to Inter

### DIFF
--- a/static/css/local.css
+++ b/static/css/local.css
@@ -1,3 +1,14 @@
+html {
+  font-family: 'Inter', sans-serif;
+  overflow-x: hidden !important;
+}
+
+@supports (font-variation-settings: normal) {
+  html {
+    font-family: 'Inter var', sans-serif;
+  }
+}
+
 body {
   padding-top: 0 !important;
 }
@@ -44,10 +55,6 @@ h6:hover a.headerlink {
   display: block;
 }
 
-html {
-  overflow-x: hidden !important;
-}
-
 .p-breadcrumbs__link + .second-level-nav, .p-breadcrumbs__link + .second-level-nav .p-breadcrumbs__link {
   display: inline-block;
   margin-bottom: 0;
@@ -74,6 +81,10 @@ html {
 .p-notification__body {
   margin-top: 1rem;
   text-align: left;
+}
+
+p {
+  max-width: 42em;
 }
 
 p:empty {
@@ -355,10 +366,6 @@ summary {
 
 .p-navigation__image {
   max-height: 2.5rem;
-}
-
-.p-breadcrumbs__items {
-  margin-bottom: 0.5rem;
 }
 
 .p-footer {

--- a/templates/common/base.tpl.html
+++ b/templates/common/base.tpl.html
@@ -11,9 +11,11 @@
   {% else %}
   <title>Linux Containers</title>
   {% endif %}
-  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-3.8.0.min.css" />
-  <link href="/static/css/local.css" rel="stylesheet"/>
-  <link href="/static/css/pygments.css" rel="stylesheet"/>
+  <link rel="preconnect" href="https://rsms.me/" />
+  <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.1.0.min.css" />
+  <link rel="stylesheet" href="/static/css/local.css" />
+  <link rel="stylesheet" href="/static/css/pygments.css" />
 
   <!-- Analytics -->
   <script>


### PR DESCRIPTION
Vanilla 4.1 was released July 31 and doesn't require major changes. The main things it changed besides adding new design patterns (which aren't used here) are:
- bolder headings in some cases
- switched to variable font weights 
- wider default max page width

At the same time, I've updated the site-wide default font to use Inter, a widely-used open source font, to reduce the Canonical-style branding of the site. This was inspired by a [conversation on Mastodon](https://mastodon.blaede.family/@cassidy/110849488580218050); the gist of which is that I always thought the Linux Containers site was actually a Canonical project due to the heavily-Canonical-style branding. I'd be interested in following up with additional brand distancing work in the future, but this is one small first step.

The two other changes I had to make to the static CSS were the max-width of paragraphs (to not wrap lines with the slightly-wider Inter) and removing a margin workaround for breadcrumbs as this appears to have been fixed in Vanilla.

Feedback welcome, especially around linking to the Inter CDN versus including the font locally—or just switching to system fonts, instead.

Before | After
------ | -----
![home-before](https://github.com/lxc/linuxcontainers.org/assets/611168/0d41fdb4-155d-4159-95e2-7bd9280c2e10) | ![home-after](https://github.com/lxc/linuxcontainers.org/assets/611168/2fca8380-7780-4596-9600-2b79e8bd6da5)
![intro-before](https://github.com/lxc/linuxcontainers.org/assets/611168/68aaa10c-ba6f-4c57-a057-dbf05128875f) | ![intro-after](https://github.com/lxc/linuxcontainers.org/assets/611168/28f98b99-b528-4f06-b560-64e92d0cd6ee)
![downloads-before](https://github.com/lxc/linuxcontainers.org/assets/611168/9cc283b4-50c3-49dc-ae79-4a74a9d28b7f) | ![downloads-after](https://github.com/lxc/linuxcontainers.org/assets/611168/95d8329e-58e9-4ba8-a238-8ce583182bbb)

