### PR TITLE
add meta tags for previews

### DIFF
--- a/templates/common/base.tpl.html
+++ b/templates/common/base.tpl.html
@@ -17,15 +17,15 @@
   <meta property="og:title" content="Linux Containers"/>
   <meta property="twitter:title" content="Linux Containers"/>
   {% endif %}
-  <meta name="description" content="The umbrella project behind LXC, LXCFS, distrobuilder, libresource and lxcri."/>
+  <meta name="description" content="The umbrella project behind Incus, LXC, LXCFS, Distrobuilder and more."/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://linuxcontainers.org/"/>
-  <meta property="og:description" content="The umbrella project behind LXC, LXCFS, distrobuilder, libresource and lxcri."/>
+  <meta property="og:description" content="The umbrella project behind Incus, LXC, LXCFS, Distrobuilder and more."/>
   <meta property="og:image" content="https://linuxcontainers.org/static/img/containers.png"/>
   <meta property="twitter:card" content="summary_large_image"/>
   <meta property="twitter:url" content="https://linuxcontainers.org/"/>
   <meta property="twitter:title" content="Linux Containers"/>
-  <meta property="twitter:description" content="The umbrella project behind LXC, LXCFS, distrobuilder, libresource and lxcri."/>
+  <meta property="twitter:description" content="The umbrella project behind Incus, LXC, LXCFS, Distrobuilder and more."/>
   <meta property="twitter:image" content="https://linuxcontainers.org/static/img/containers.png"/>
   <link rel="preconnect" href="https://rsms.me/" />
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/templates/common/base.tpl.html
+++ b/templates/common/base.tpl.html
@@ -8,9 +8,25 @@
 
   {% if page_title %}
   <title>Linux Containers - {{ page_title }}</title>
+  <meta name="title" content="Linux Containers - {{ page_title }}"/>
+  <meta property="og:title" content="Linux Containers - {{ page_title }}"/>
+  <meta property="twitter:title" content="Linux Containers - {{ page_title }}"/>
   {% else %}
   <title>Linux Containers</title>
+  <meta name="title" content="Linux Containers"/>
+  <meta property="og:title" content="Linux Containers"/>
+  <meta property="twitter:title" content="Linux Containers"/>
   {% endif %}
+  <meta name="description" content="The umbrella project behind LXC, LXCFS, distrobuilder, libresource and lxcri."/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:url" content="https://linuxcontainers.org/"/>
+  <meta property="og:description" content="The umbrella project behind LXC, LXCFS, distrobuilder, libresource and lxcri."/>
+  <meta property="og:image" content="https://linuxcontainers.org/static/img/containers.png"/>
+  <meta property="twitter:card" content="summary_large_image"/>
+  <meta property="twitter:url" content="https://linuxcontainers.org/"/>
+  <meta property="twitter:title" content="Linux Containers"/>
+  <meta property="twitter:description" content="The umbrella project behind LXC, LXCFS, distrobuilder, libresource and lxcri."/>
+  <meta property="twitter:image" content="https://linuxcontainers.org/static/img/containers.png"/>
   <link rel="preconnect" href="https://rsms.me/" />
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
   <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.1.0.min.css" />


### PR DESCRIPTION
This allows for https://linuxcontainers.org/ to offer a preview when shared on chat platforms or the usual social networks.