### PR TITLE
Edit getting-started.md: note constraints on DHCP reservation

### DIFF
--- a/content/lxc/getting-started.md
+++ b/content/lxc/getting-started.md
@@ -233,6 +233,12 @@ Add the DHCP reservation.
 
     root@host:~# echo "dhcp-host=mycontainer,10.0.3.100" >>/etc/lxc/dnsmasq.conf
 
+Note: the IP address (i.e. `10.0.3.100` in the command above) must be within `LXC_DHCP_RANGE`. To see `LXC_DHCP_RANGE`, open `/etc/lxc/dnsmasq.conf`. Suppose `LXC_DHCP_RANGE="10.0.1.2,10.0.1.254"`. Then the command above should be
+
+    root@host:~# echo "dhcp-host=mycontainer,10.0.1.100" >>/etc/lxc/dnsmasq.conf
+
+instead of the command with `10.0.3.100`. Moreover, the IP address must not already be in use. One way to pick an available IP address is use one of the addresses assigned dynamically while working through the section above.
+
 Restart the `lxc-net` service so the DHCP reservation is enabled.
 
     root@host:~# service lxc-net restart


### PR DESCRIPTION
I propose the `Getting Started: DHCP Reservation` section notes the constraints on the value for the IP address.

In the commit on this pull request I provide example text. I ask the maintainers to rewrite the example text however they wish.

### The problem I encountered that motivates this pull request

I followed the instructions on https://linuxcontainers.org/lxc/getting-started/ through the steps in https://linuxcontainers.org/lxc/getting-started/#dhcp-reservation. 

But I failed to get `mycontainer` to have the assigned IP address.

I believe the reason for my failure is that my `/etc/default/lxc-net` file includes
```bash
LXC_BRIDGE="lxcbr0"
LXC_ADDR="10.0.1.1"
LXC_NETMASK="255.255.255.0"
LXC_NETWORK="10.0.1.0/24"
LXC_DHCP_RANGE="10.0.1.2,10.0.1.254"
LXC_DHCP_MAX="253"
```
Notice the `10.0.1` prefix rather than `10.0.3`.

The instructions in https://linuxcontainers.org/lxc/getting-started/#dhcp-reservation include

```bash
root@host:~# echo "dhcp-host=mycontainer,10.0.3.100" >>/etc/lxc/dnsmasq.conf
```
where `10.0.3.100` is outside the range `LXC_DHCP_RANGE` from my `/etc/default/lxc-net` file.

### What I did to resolve the problem
Later I succeeded in getting `mycontainer` to have the IP address from `/etc/lxc/dnsmasq.conf` when I made the value for the IP address in `/etc/lxc/dnsmasq.conf` satisfy two constraints:
 1. IP address is within `LXC_DHCP_RANGE` and
 2. IP address different than any currently used IP address (e.g. `10.0.1.100` did not work for me but `10.0.1.84` did).

### Environment I used 
Host:
Ubuntu 22.04 jammy amd64

Container image: 
Ubuntu 22.04 jammy amd64
[I also tried others while experimenting]

Please let me know whether there is more information I can share that will be helpful.