### PR TITLE
edit getting-started.md: note that firewall can block container from receiving IP address

### DIFF
--- a/content/lxc/getting-started.md
+++ b/content/lxc/getting-started.md
@@ -187,6 +187,15 @@ If we wait about 5 seconds and check again, then the container does have an IP a
     NAME        STATE   AUTOSTART GROUPS IPV4       IPV6 UNPRIVILEGED
     mycontainer RUNNING 1         -      10.0.3.152 -    false
 
+If the container does not have an IP address, we may need to [configure the firewall](https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/). For example, on Ubuntu 22.04
+
+
+    root@host:~# ufw allow in on lxcbr0
+    root@host:~# ufw route allow in on lxcbr0
+    root@host:~# ufw route allow out on lxcbr0
+
+where the value `lxcbr0` comes from `LXC_BRIDGE` in `/etc/default/lxc-net`.
+
 If we are going to do something in the container that requires access to the Internet, we need to wait until the container has an IP address. One possibilty is to poll the output of `lxc-info` until it includes an IP address.
 
     root@host:~# lxc-start --name mycontainer


### PR DESCRIPTION
I propose the `Getting Started: IP Address` section notes that a firewall may block container from receiving IP address.

In the commit on this pull request I provide example text. I ask the maintainers to rewrite the example text to their liking.

The example text I provide is likely over-specific. It refers to Ubuntu distribution in particular rather than Linux distributions generally.

### The problem I encountered that motivates this pull request
I followed the instructions on https://linuxcontainers.org/lxc/getting-started/ through the steps in https://linuxcontainers.org/lxc/getting-started/#ip-address.

But I failed to get `mycontainer` to have an IP address.

### What I did
I searched and found
https://discuss.linuxcontainers.org/t/lxd-bridge-doesnt-work-with-ipv4-and-ufw-with-nftables/10034/17, including 
```
sudo ufw allow in on lxdbr0
sudo ufw route allow in on lxdbr0
sudo ufw route allow out on lxdbr0
```
In those commands I replaced `lxdbr0` with `lxcbr0` -- the value for `LXC_BRIDGE` in `/etc/default/lxc-net`. After I executed
```
root@host:~# ufw allow in on lxcbr0
root@host:~# ufw route allow in on lxcbr0
root@host:~# ufw route allow out on lxcbr0
root@host:~# service lxc-net restart
root@host:~# lxc-stop --name mycontainer
root@host:~# lxc-destroy --name mycontainer
root@host:~# lxc-create --name mycontainer --template download -- --dist ubuntu --release jammy --arch amd64
root@host:~# lxc-start --name mycontainer
```
the container received an IP address.

### Related issue
I found #639 , but I do not find [that page](https://linuxcontainers.org/lxd/getting-started-cli) on the site.

Thank you for looking into this.