### PR TITLE
Fix navigation link of website logo

### DIFF
--- a/templates/common/header.tpl.html
+++ b/templates/common/header.tpl.html
@@ -2,7 +2,7 @@
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
-        <a class="p-navigation__item" href="/">
+        <a class="p-navigation__item" href="/{{ page_language[0] }}/">
          <img class="p-navigation__image" src="/static/img/containers.small.png" alt="Linux containers logo" border="0" />
         </a>
       </div>


### PR DESCRIPTION
I found that the top-left logo of website will always navigate to the English version, so I appended the url with language code.