### PR TITLE
Fix news header levels

### DIFF
--- a/content/STRUCTURE.de.json
+++ b/content/STRUCTURE.de.json
@@ -34,7 +34,7 @@
      "generator": "news",
      "meta": {"dir": "/content/incus/news/",
               "input": "incus/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -93,7 +93,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxc/news/",
               "input": "lxc/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -197,7 +197,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxcfs/news/",
               "input": "lxcfs/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -272,7 +272,7 @@
      "generator": "news",
      "meta": {"dir": "/content/distrobuilder/news/",
               "input": "distrobuilder/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -339,7 +339,7 @@
      "menu": ["CGManager", "News"],
      "generator": "markdown",
      "meta": {"input": "cgmanager/news.de.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.id.json
+++ b/content/STRUCTURE.id.json
@@ -34,7 +34,7 @@
      "generator": "news",
      "meta": {"dir": "/content/incus/news/",
               "input": "incus/news.id.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -93,7 +93,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxc/news/",
               "input": "lxc/news.id.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -197,7 +197,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxcfs/news/",
               "input": "lxcfs/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -272,7 +272,7 @@
      "generator": "news",
      "meta": {"dir": "/content/distrobuilder/news/",
               "input": "distrobuilder/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -339,7 +339,7 @@
      "menu": ["CGManager", "News"],
      "generator": "markdown",
      "meta": {"input": "cgmanager/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.ja.json
+++ b/content/STRUCTURE.ja.json
@@ -93,7 +93,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxc/news.ja/",
               "input": "lxc/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.ja.json
+++ b/content/STRUCTURE.ja.json
@@ -34,7 +34,7 @@
      "generator": "news",
      "meta": {"dir": "/content/incus/news.ja/",
               "input": "incus/news.ja.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -268,7 +268,7 @@
      "generator": "news",
      "meta": {"dir": "/content/distrobuilder/news/",
               "input": "distrobuilder/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
@@ -331,7 +331,7 @@
      "menu": ["CGManager", "ニュース"],
      "generator": "markdown",
      "meta": {"input": "cgmanager/news.ja.md",
-              "toc_depth": "2-2"}},
+              "toc_depth": "2-3"}},
 
     {"path": "/cgmanager/getting-started/",
      "title": "CGManager - はじめに",

--- a/content/STRUCTURE.ja.json
+++ b/content/STRUCTURE.ja.json
@@ -193,7 +193,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxcfs/news.ja/",
               "input": "lxcfs/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -339,7 +339,7 @@
      "menu": ["CGManager", "News"],
      "generator": "markdown",
      "meta": {"input": "cgmanager/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -197,7 +197,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxcfs/news/",
               "input": "lxcfs/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -93,7 +93,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxc/news/",
               "input": "lxc/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -272,7 +272,7 @@
      "generator": "news",
      "meta": {"dir": "/content/distrobuilder/news/",
               "input": "distrobuilder/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 

--- a/content/STRUCTURE.zh-cn.json
+++ b/content/STRUCTURE.zh-cn.json
@@ -35,7 +35,7 @@
      "generator": "news",
      "meta": {"dir": "/content/incus/news/",
               "input": "incus/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "旧闻",
               "str_back": "回到概览"}},
 
@@ -96,7 +96,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxc/news/",
               "input": "lxc/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "旧闻",
               "str_back": "回到概览"}},
 
@@ -198,7 +198,7 @@
      "generator": "news",
      "meta": {"dir": "/content/lxcfs/news/",
               "input": "lxcfs/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "旧闻",
               "str_back": "回到概览"}},
 
@@ -273,7 +273,7 @@
      "generator": "news",
      "meta": {"dir": "/content/distrobuilder/news/",
               "input": "distrobuilder/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "旧闻",
               "str_back": "回到概览"}},
 
@@ -340,7 +340,7 @@
      "menu": ["CGManager", "新闻"],
      "generator": "markdown",
      "meta": {"input": "cgmanager/news.md",
-              "toc_depth": "2-2",
+              "toc_depth": "2-3",
               "str_older": "旧闻",
               "str_back": "回到概览"}},
 

--- a/content/distrobuilder/news/distrobuilder-1.0.yaml
+++ b/content/distrobuilder/news/distrobuilder-1.0.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 1.0 has been released
 date: 2019/10/21 22:10
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-1-0-has-been-released/5987
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce its initial release, distrobuilder 1.0!
 
   Distrobuilder is a tool which produces root filesystems, LXC and LXD images.
@@ -15,8 +15,8 @@ content: |-
 
   It can be seen at work [here](https://jenkins.linuxcontainers.org/view/Images/) building the many images that we [publish daily](https://images.linuxcontainers.org).
 
-  ### Main components
-  #### Image details
+  # Main components
+  ## Image details
   This first section covers the usual suspects, the image name, distribution, release, description and architecture.
 
   Example:
@@ -28,7 +28,7 @@ content: |-
         description: Ubuntu {{ image.release }}
         architecture: x86_64
 
-  #### Image sources
+  ## Image sources
   The image sources are distribution specific logic (in Go) to either retrieve a suitable minimal base image or produce one from scratch using commonly available tooling (like `debootstrap`).
 
   Example:
@@ -41,7 +41,7 @@ content: |-
           - 0x54CC74307A2C6DC9CE618269CD84BCED626471F1
           - 0x6D9278A33A9AB3146262DCECF93525A88B699029
 
-  #### Packages and package managers
+  ## Packages and package managers
   Distrobuilder currently supports:
 
    - apk
@@ -92,7 +92,7 @@ content: |-
              variants:
               - cloud
 
-  #### Files
+  ## Files
   Distrobuilder can generate common files like hostname/hosts, some amount of init system configuration files, cloud-init templates and more generating templating for LXD containers.
 
   Example:
@@ -113,7 +113,7 @@ content: |-
        - path: /etc/machine-id
          generator: remove
 
-  #### Actions
+  ## Actions
   Actions are effectively a number of hook points at which a provided shell scripts can be run. Those hooks currently are:
 
    - post-unpack (after the source image was retrieved and unpacked)
@@ -153,7 +153,7 @@ content: |-
           variants:
            - cloud
 
-  #### Architecture maps
+  ## Architecture maps
   One of those tiny internal details, but pretty much every Linux distribution has its own name for the various hardware architecture. Distrobuilder has maps for the most ones, translating between kernel architectures and the name used by the distribution.
 
   This allows for consistent architecture naming in the output, to line up with the patterns used by LXC and LXD.
@@ -164,15 +164,15 @@ content: |-
         architecture_map: debian
 
 
-  #### Conditions
+  ## Conditions
   Packages, Files and Actions can all be set to only apply to specific image variants, distribution releases or OS architectures, making it possible to have a single YAML file for an entire Linux distribution. Some examples of this can be found in the previous examples.
 
-  ### Examples
+  # Examples
   All the production YAML files for [our image server](https://images.linuxcontainers.org) can be [found here](https://github.com/lxc/lxc-ci/tree/master/images).
 
   Those are all pretty featureful and will generally be used to generate multiple releases of the distribution for multiple architectures and often for two variants (standard and cloud-init enabled).
 
-  ### Supported distributions
+  # Supported distributions
   Distrobuilder can build images for the following distributions:
 
    - Alpine Linux
@@ -196,7 +196,7 @@ content: |-
 
   Adding a new distribution is usually pretty straightforward and just requires adding a new package manager wrapper and logic to fetch a minimal source image or to produce that image directly.
 
-  ### Architecture support
+  # Architecture support
   Distrobuilder supports and is actively used on:
 
    - aarch64
@@ -208,16 +208,16 @@ content: |-
 
   Only native image building is supported at this point, no support for cross-building through `qemu-user-static` or similar tooling.
 
-  ### Security
+  # Security
   A common issue with the older shell scripts in `lxc-templates` was the lack of validation of the downloaded packages and other artifacts instrumental to the image building process. This was often caused by lack of HTTPS servers to download those files from combined with difficulty of dealing with GPG for the very many distributions we had to support.
 
   Distrobuilder changes that model by using pre-built minimal images downloaded over HTTPS or GPG validated (with support for key retrieval or in-line keyring), then either adding on top of that base image or using the base image to produce a whole new image using the distribution's native tooling.
 
-  ### How to get it
+  # How to get it
   This new LXD release is already available for you to try on our [demo service](https://linuxcontainers.org/lxd/try-it/).
 
-  ### Installing it
-  #### Using the snap
+  # Installing it
+  ## Using the snap
   A snap package is available with both `stable` and `edge` releases.
 
   It can be installed with:
@@ -228,7 +228,7 @@ content: |-
 
       snap install distrobuilder --classic --edge
 
-  #### From source
+  ## From source
   The release tarballs can be found on our [download page](https://linuxcontainers.org/distrobuilder/downloads/). Those include a snapshot of all the Go dependencies needed to build distrobuilder.
 
   Alternatively, the current upstream code can be built with:

--- a/content/distrobuilder/news/distrobuilder-1.1.yaml
+++ b/content/distrobuilder/news/distrobuilder-1.1.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 1.1 has been released
 date: 2020/08/20 21:08
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-1-1-has-been-released/8749
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce its initial release, distrobuilder 1.1!
 
   This release's highlight is the introduction of VM image building support following LXD's introduction of VM support.
@@ -138,7 +138,7 @@ content: |-
    - doc/generators: Add fstab
   [/details]
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [distrobuilder-1.1.tar.gz](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-1.1.tar.gz)
    - GPG signature: [distrobuilder-1.1.tar.gz.asc](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-1.1.tar.gz.asc)

--- a/content/distrobuilder/news/distrobuilder-1.2.yaml
+++ b/content/distrobuilder/news/distrobuilder-1.2.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 1.2 has been released
 date: 2021/03/23 15:03
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-1-2-has-been-released/10592
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce its initial release, distrobuilder 1.2!
 
   This release's highlight is the introduction of Windows image repacking.
@@ -72,7 +72,7 @@ content: |-
    - Update gomod
   [/details]
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [distrobuilder-1.2.tar.gz](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-1.2.tar.gz)
    - GPG signature: [distrobuilder-1.2.tar.gz.asc](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-1.2.tar.gz.asc)

--- a/content/distrobuilder/news/distrobuilder-1.3.yaml
+++ b/content/distrobuilder/news/distrobuilder-1.3.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 1.3 has been released
 date: 2021/08/09 18:08
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-1-3-has-been-released/11836
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce its initial release, distrobuilder 1.3!
 
   The main highlights are:
@@ -165,7 +165,7 @@ content: |-
    - main: Support ISO generation with mkisofs
   [/details]
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [distrobuilder-1.3.tar.gz](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-1.3.tar.gz)
    - GPG signature: [distrobuilder-1.3.tar.gz.asc](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-1.3.tar.gz.asc)

--- a/content/distrobuilder/news/distrobuilder-2.0.yaml
+++ b/content/distrobuilder/news/distrobuilder-2.0.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 2.0 has been released
 date: 2021/10/18 03:10
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-2-0-has-been-released/12403
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce its initial release, distrobuilder 2.0!
 
   As usual, this release fixes a variety of issues as Linux distributions evolve and change the way they're built. Additionally, it also improves the Windows ISO repack feature quite a bit and introduces support for directly importing an image into LXD
@@ -66,7 +66,7 @@ content: |-
    - Update gomod
   [/details]
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [distrobuilder-2.0.tar.gz](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-2.0.tar.gz)
    - GPG signature: [distrobuilder-2.0.tar.gz.asc](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-2.0.tar.gz.asc)

--- a/content/distrobuilder/news/distrobuilder-2.1.yaml
+++ b/content/distrobuilder/news/distrobuilder-2.1.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 2.1 has been released
 date: 2022/04/27 16:04
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-2-1-has-been-released/13954
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce the release of distrobuilder 2.1!
 
   Outside of the usual updates to account for changes made by various distributions, the main highlights are:
@@ -91,7 +91,7 @@ content: |-
    - windows: Add viostor driver
   [/details]
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [distrobuilder-2.1.tar.gz](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-2.1.tar.gz)
    - GPG signature: [distrobuilder-2.1.tar.gz.asc](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-2.1.tar.gz.asc)

--- a/content/distrobuilder/news/distrobuilder-3-0-has-been-released.yaml
+++ b/content/distrobuilder/news/distrobuilder-3-0-has-been-released.yaml
@@ -2,7 +2,7 @@ title: Distrobuilder 3.0 has been released
 date: 2023/11/11 03:11
 origin: https://discuss.linuxcontainers.org/t/distrobuilder-3-0-has-been-released/18260
 content: |-
-  ### Introduction
+  # Introduction
   The distrobuilder team is proud to announce the release of distrobuilder 3.0!
 
   Outside of the usual updates to account for changes made by various distributions, the main highlights are:
@@ -203,7 +203,7 @@ content: |-
    - Update Vyos rolling update iso url
   [/details]
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [distrobuilder-3.0.tar.gz](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-3.0.tar.gz)
    - GPG signature: [distrobuilder-3.0.tar.gz.asc](https://linuxcontainers.org/downloads/distrobuilder/distrobuilder-3.0.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-1.0-eol.yaml
+++ b/content/lxc/news.ja/lxc-1.0-eol.yaml
@@ -2,7 +2,7 @@ title: LXC 1.0 - サポート終了（EOL）のお知らせ
 date: 2019/06/26 16:06
 origin: https://discuss.linuxcontainers.org/t/lxc-1-0-end-of-life-announcement/5111
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC 1.0 LTS branch has reached its end of life.
   -->
@@ -23,7 +23,7 @@ content: |-
   -->
   まだお使いのユーザーはできるだけ早く、サポートされているリリースへのアップグレードを行う必要があります。
 
-  ### 長期サポートリリース <!-- Long term support releases -->
+  # 長期サポートリリース <!-- Long term support releases -->
   <!--
   LXC upstream commits to 5 years support for its LTS branches.
   Such branches exist for LXC, LXCFS and LXD and see bugfixes and security fixes backported to them.
@@ -36,7 +36,7 @@ content: |-
   -->
   LTS ブランチには新機能は追加されず、最新の LTS ブランチにはほとんどのバグフィックスがバックポートされます。新しい LTS ブランチがリリースされると、前の LTS リリースにはセキュリティ修正と重大なバグフィックスのみが行われます。
 
-  ### 移行パス <!-- Migration paths -->
+  # 移行パス <!-- Migration paths -->
   <!--
   LXC 1.0 users can upgrade to LXC 2.0 LTS without any expected disruption nor configuration changes required.
   -->
@@ -47,7 +47,7 @@ content: |-
   -->
   LXC 3.0 LTS へのアップグレードも可能で、一旦 2.0 へアップグレードする必要はありません。しかし 3.0 では設定オプションに多数の更新があるため、`lxc-update-config` を実行する必要があり、手動で変更をいくつか行う必要があるかもしれません。
 
-  ### 現在サポート中のリリース <!-- Currently supported releases -->
+  # 現在サポート中のリリース <!-- Currently supported releases -->
   <!--
   There are currently 3 supported releases of LXC:
   -->

--- a/content/lxc/news.ja/lxc-1.0.0.yaml
+++ b/content/lxc/news.ja/lxc-1.0.0.yaml
@@ -2,7 +2,7 @@ title: LXC 1.0.0 リリースのお知らせ
 date: 2014/02/20 00:00
 content: |-
   
-  ### <!-- Introduction -->はじめに
+  # <!-- Introduction -->はじめに
   <!-- It's with great pleasure that the LXC team is announcing the
           release of LXC 1.0! -->
     LXC チームが LXC 1.0 のリリースをアナウンスできるのは大きな喜びです!
@@ -31,7 +31,7 @@ content: |-
     どのような変更がされ、開発がどのように進んだのかをご覧になりたい場合は、メインリポジトリが <a href="https://github.com/lxc/lxc">GitHub</a> にあります。
   
   
-  ### <!-- New features -->新機能について
+  # <!-- New features -->新機能について
   <!-- LXC 1.0 is the result of 10 months of development and over a
           thousand commits, including a major rework of the way LXC is
           structured.  It's therefore near impossible to come up with a
@@ -77,7 +77,7 @@ content: |-
   
   
   
-  ### <!-- LXC 1.0 moving forward -->
+  # <!-- LXC 1.0 moving forward -->
   <!-- LXC 1.0 is the first production ready release of LXC and it
           comes with a commitment from upstream to maintain it until at
           least Ubuntu 14.04 LTS reaches end of life in April 2019.
@@ -93,7 +93,7 @@ content: |-
     stable ブランチは別に管理され、必要に応じてバックポートされます。頻繁に 1.0 のバグフィックス版を出す予定なので、各ディストリビューションは単純にそれを使用すれば良く、stable ブランチを自身でフォローする手間を省くことができます。
   
   
-  ### <!-- Bug reports and contact information -->バグレポートと連絡先
+  # <!-- Bug reports and contact information -->バグレポートと連絡先
   <!-- Bug reports should be filed on
           <a href="https://github.com/lxc/lxc/issues">GitHub</a>
           or if you do not wish to create an account, by e-mail to the

--- a/content/lxc/news.ja/lxc-1.0.1.yaml
+++ b/content/lxc/news.ja/lxc-1.0.1.yaml
@@ -4,7 +4,7 @@ content: |-
   
   <!-- This is the first bugfix release for the LXC 1.0 series. -->このリリースは LXC 1.0 シリーズの最初のバグフィックスとなるリリースです。
   
-  ### <!-- Changes -->変更点
+  # <!-- Changes -->変更点
   
   
   * <!-- core: Detect the use of rshared / and properly work
@@ -80,7 +80,7 @@ content: |-
   
   
   
-  ### <!-- Downloads -->ダウンロード
+  # <!-- Downloads -->ダウンロード
   <!-- The release tarballs may be found on our
           [download page</a> and we expect most
           distributions will very soon ship a packaged version of LXC 1.0.1. -->

--- a/content/lxc/news.ja/lxc-1.0.10.yaml
+++ b/content/lxc/news.ja/lxc-1.0.10.yaml
@@ -53,7 +53,7 @@ content: |-
    * commands: 機能と関係のない変更を行いました (訳注: デバッグログの追加、int -> size\_t への修正)<!-- non-functional changes -->
    * lxccontainer: NULL ポインタへの参照をしないようにしました <!-- avoid NULL pointer dereference -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.10.

--- a/content/lxc/news.ja/lxc-1.0.11.yaml
+++ b/content/lxc/news.ja/lxc-1.0.11.yaml
@@ -60,7 +60,7 @@ content: |-
    * utils: 'stdoutfd' を代入していない 'ts-\>stdoutfd' のバグを修正しました <!-- Fix the bug of 'ts-\>stdoutfd' did not fill with parameters 'stdoutfd' -->
    * utils: lxc\_popen() 内の不要な割り当てを削除しました <!-- Remove dead assignments in lxc\_popen() -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.11.

--- a/content/lxc/news.ja/lxc-1.0.2.yaml
+++ b/content/lxc/news.ja/lxc-1.0.2.yaml
@@ -4,7 +4,7 @@ content: |-
   
   <!-- This is the second bugfix release for the LXC 1.0 series. -->このリリースは LXC 1.0 シリーズの 2 回目のバグフィックスとなるリリースです。
   
-  ### <!-- Changes -->変更点
+  # <!-- Changes -->変更点
   
   
   * <!-- core: Fix parsing lxc.netwotk.type = none -->core: lxc.network.type = none を指定した場合の不具合を修正しました
@@ -47,7 +47,7 @@ content: |-
   
   
   
-  ### <!-- Downloads -->ダウンロード
+  # <!-- Downloads -->ダウンロード
   <!-- The release tarballs may be found on our
           [download page</a> and we expect most
           distributions will very soon ship a packaged version of LXC 1.0.2. -->

--- a/content/lxc/news.ja/lxc-1.0.3.yaml
+++ b/content/lxc/news.ja/lxc-1.0.3.yaml
@@ -4,7 +4,7 @@ content: |-
   
   <!-- This is the third bugfix release for the LXC 1.0 series. -->このリリースは LXC 1.0 シリーズの 3 回目のバグフィックスとなるリリースです。
   
-  ### <!-- Changes -->変更点
+  # <!-- Changes -->変更点
   
   
   * <!-- core: Always initialize netpipe in lxc_spawn. -->core: lxc_spawn 中で常に netpipe を初期化するようにしました (訳注: 非特権コンテナのリブート時に存在しないパイプに対してメッセージを送ることのないように lxc_spawn 中でパイプを初期化するように修正されています)
@@ -64,7 +64,7 @@ content: |-
   
   
   
-  ### <!-- Downloads -->ダウンロード
+  # <!-- Downloads -->ダウンロード
   <!-- The release tarballs may be found on our
           [download page</a> and we expect most
           distributions will very soon ship a packaged version of LXC 1.0.3. -->

--- a/content/lxc/news.ja/lxc-1.0.4.yaml
+++ b/content/lxc/news.ja/lxc-1.0.4.yaml
@@ -4,7 +4,7 @@ content: |-
   
   <!-- This is the fourth bugfix release for the LXC 1.0 series. -->このリリースは LXC 1.0 シリーズの 4 回目のバグフィックスとなるリリースです。
   
-  ### <!-- Changes -->変更点
+  # <!-- Changes -->変更点
   
   
   * <!-- core: Don't call nih_dbus_setup for cgmanager as it's
@@ -108,7 +108,7 @@ content: |-
   <!-- Those stable fixes were brought to you by 14 individual
           contributors. -->これらの stable の修正は 14 名のコントリビュータによってなされました。
   
-  ### <!-- Downloads -->ダウンロード
+  # <!-- Downloads -->ダウンロード
   <!-- The release tarballs may be found on our
           [download page</a> and we expect most
           distributions will very soon ship a packaged version of LXC 1.0.4. -->

--- a/content/lxc/news.ja/lxc-1.0.5.yaml
+++ b/content/lxc/news.ja/lxc-1.0.5.yaml
@@ -4,7 +4,7 @@ content: |-
   
   <!-- This is the fifth bugfix release for the LXC 1.0 series. -->このリリースは LXC 1.0 シリーズの 5 回目のバグフィックスとなるリリースです。
   
-  ### seccomp profile
+  # seccomp profile
   
     <!--
         Outside of the usual bugfixes, this release also introduces
@@ -41,7 +41,7 @@ content: |-
     共通の設定を読み込む仕組みを使っていないコンテナでこの機能をオンにしたい場合は、"lxc.seccomp = /usr/share/lxc/config/common.seccomp" というような設定を、コンテナの設定ファイルに追加します。
   
   
-  ### <!-- Changes -->変更点
+  # <!-- Changes -->変更点
   
   
   * <!-- core: Fix unprivileged containers to work with recent
@@ -84,7 +84,7 @@ content: |-
   <!-- Those stable fixes were brought to you by 11 individual
           contributors. -->これらの stable の修正は 11 名のコントリビュータによってなされました。
   
-  ### <!-- Downloads -->ダウンロード
+  # <!-- Downloads -->ダウンロード
   <!-- The release tarballs may be found on our
           [download page</a> and we expect most
           distributions will very soon ship a packaged version of LXC 1.0.5. -->

--- a/content/lxc/news.ja/lxc-1.0.6.yaml
+++ b/content/lxc/news.ja/lxc-1.0.6.yaml
@@ -13,7 +13,7 @@ content: |-
     LXC 1.0 と将来リリースする LXC 1.1 の両方を簡単にサポートするために、このバージョンでは lxc-start に -F オプションを追加しました。(現在の 1.0 で) デフォルトでフォアグラウンドで起動している lxc-start ではこのオプションは不要ですが、この動きは LXC 1.1 で変わる予定です (訳注: バックグラウンドがデフォルトに変わる予定です)。1.0 で -F を導入したのは、アップグレード後も作成したスクリプトが変わらずに動くようにするためです。
   
   
-  ### <!-- Changes -->変更点
+  # <!-- Changes -->変更点
   
   * <!-- rootfs_is_blockdev: don't run if no rootfs is specified -->rootfs_is_blockdev: rootfs が指定されていないときには実行されないようにしました (訳注: rootfs が指定されていない場合はストレージバックエンドがブロックデバイスかどうかチェックを行う処理を実行しないようにしました)
   * <!-- confile: sanity-check netdev-&#62;type before setting
@@ -110,7 +110,7 @@ content: |-
   <!-- Those stable fixes were brought to you by 24 individual
           contributors. -->これらの stable の修正は 24 名のコントリビュータによってなされました。
   
-  ### <!-- Downloads -->
+  # <!-- Downloads -->
   <!-- The release tarballs may be found on our
           <a href="/downloads/">download page</a> and we expect most
           distributions will very soon ship a packaged version of LXC 1.0.6. -->

--- a/content/lxc/news.ja/lxc-1.0.7.yaml
+++ b/content/lxc/news.ja/lxc-1.0.7.yaml
@@ -5,7 +5,7 @@ content: |-
   <!-- This is the seventh bugfix release for the LXC 1.0 series. -->
   このリリースは LXC 1.0 シリーズの 7 回目のバグフィックスとなるリリースです。
   
-  ### 変更点 <!-- Changes -->
+  # 変更点 <!-- Changes -->
   
   コア <!-- Core -->:
   
@@ -96,7 +96,7 @@ content: |-
   -->
   これらの stable の修正は 27 名のコントリビュータによってなされました。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.7.

--- a/content/lxc/news.ja/lxc-1.0.8.yaml
+++ b/content/lxc/news.ja/lxc-1.0.8.yaml
@@ -205,7 +205,7 @@ content: |-
   -->
   これらの stable の修正は 59 名のコントリビュータによってなされました。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.8.

--- a/content/lxc/news.ja/lxc-1.0.9.yaml
+++ b/content/lxc/news.ja/lxc-1.0.9.yaml
@@ -153,7 +153,7 @@ content: |-
    * tree-wide: readdir\_r() を readdir() に置き換えました <!-- replace readdir\_r() with readdir() -->
    * attach: attach するプロセスに procfd を送らないようにしました <!-- do not send procfd to attached process -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.9.

--- a/content/lxc/news.ja/lxc-1.1.0.yaml
+++ b/content/lxc/news.ja/lxc-1.1.0.yaml
@@ -20,7 +20,7 @@ content: |-
   -->
   一方でそこまでの厳密さが不要であれば、LXC 1.1 を cgmanager 0.35 以降、lxcfs 0.5 以降と一緒に使うこともおすすめです。
   
-  ### 注目の新機能 <!-- Highlights -->
+  # 注目の新機能 <!-- Highlights -->
   <!--
   LXC 1.1 introduces checkpoint/restore support for containers through CRIU.
   This allows to serialize the container running state to disk, for live migration or for later local restoration
@@ -45,7 +45,7 @@ content: |-
   <!-- This release was made possible by contributions from 84 developers. -->
   このリリースは 84 名の開発者からのコントリビュートによりリリースできました。
   
-  ### 新機能<!-- New features -->
+  # 新機能<!-- New features -->
    * lxc-autostart: 新たに -A/--ignore-auto オプションを追加しました (すべてのコンテナを起動できます) <!-- New -A/--ignore-auto flag (starts all containers) -->
    * lxc-ls: 新たな出力項目 "interface" を追加しました <!-- New "interface" field -->
    * centos/fedora: root\_password\_expired 環境変数を追加しました (デフォルト yes) <!-- Added a root\_password\_expired environment variable (defaults to yes) -->
@@ -76,7 +76,7 @@ content: |-
    * core: 新たに common.conf.d ディレクトリが利用可能になりました。ユーザ、パッケージが全てのコンテナに反映させたい設定を追加できるようになりました<!-- A new common.conf.d configuration directory is available for users and packages to drop configuration snippets to be applied to all containers -->
    * core: LXC が container_ttys 環境変数を設定するようになりました <!-- The container\_ttys environment variable is now set by LXC -->
   
-  ### 動作の変更点<!-- Change in behavior -->
+  # 動作の変更点<!-- Change in behavior -->
    * lxc-create で -t オプションが必須になりました。以前のようにテンプレートなしの場合は "none" を使用します <!-- lxc-create now requires be passed (-t), use "none" for the old behavior. -->
    * スナップショットがコンテナのディレクトリ内に保存されるようになりました <!-- snapshots are now stored in the container's directory -->
    * PER\_LINUX32 に対する lxc.arch は i686 を出力するようになりました <!-- lxc.arch for PER\_LINUX32 is now output as i686 -->
@@ -90,7 +90,7 @@ content: |-
    * core: clear\_config\_item はリスト (lxc\_list) のみに影響するようになりました。他では set\_config\_item を使用してください <!-- clear\_config\_item now exclusively Affects lists (lxc\_list) entries. set\_config\_item should be used for anything else. -->
    * templates: 全てのテンプレートで lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed を使うようになりました (安全なデフォルト設定です) <!-- All templates now use lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed (safe default configuration) -->
   
-  ### ダウンロード<!-- Downloads -->
+  # ダウンロード<!-- Downloads -->
   <!-- The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.0, unless they decide to stick to the long term 1.0 release. -->
   このリリースの tarball は [ダウンロードページ](/lxc/downloads/) から取得できます。そして、各ディストリビューションが長期サポートの 1.0 リリースの採用を続ける決定をしない場合は、すぐに LXC 1.1.0 のパッケージをリリースするでしょう。

--- a/content/lxc/news.ja/lxc-1.1.1.yaml
+++ b/content/lxc/news.ja/lxc-1.1.1.yaml
@@ -6,7 +6,7 @@ content: |-
   -->
   このリリースは LXC 1.1 の初めてのバグフィックスリリースです。
   
-  ### 変更点 <!-- Changes -->
+  # 変更点 <!-- Changes -->
   
   * config: デフォルトで FUSE へのアクセスが可能になりました (元々ほとんどのテンプレートそれぞれで許可されていました) <!-- Allow FUSE access by default (instead of individually in most templates) -->
    * proc:mixed を使った場合、/proc/sys/net が書き込み可能になりました (ネットワーク設定に必要です)<!-- Make /proc/sys/net writable when using proc:mixed (required for network config) -->
@@ -27,7 +27,7 @@ content: |-
   -->
   これらの stable の修正は 13 名のコントリビュータによってなされました。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.1.

--- a/content/lxc/news.ja/lxc-1.1.2.yaml
+++ b/content/lxc/news.ja/lxc-1.1.2.yaml
@@ -6,7 +6,7 @@ content: |-
   -->
   このリリースは LXC 1.1 の 2 回目のバグフィックスリリースです。
   
-  ### 変更点 <!-- Changes -->
+  # 変更点 <!-- Changes -->
   
    * core: attach 中の tty でない stdin に関する修正を行いました <!-- Fix non-tty stdin during attach -->
    * core: コンテナのロギングの改良を行いました <!-- Improved container logging -->
@@ -25,7 +25,7 @@ content: |-
   -->
   これらの stable の修正は 9 名のコントリビュータによってなされました。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.2.

--- a/content/lxc/news.ja/lxc-1.1.3.yaml
+++ b/content/lxc/news.ja/lxc-1.1.3.yaml
@@ -6,7 +6,7 @@ content: |-
   -->
   このリリースは LXC 1.1 の 3 回目のバグフィックスリリースです。
   
-  ### 変更点 <!-- Changes -->
+  # 変更点 <!-- Changes -->
   
   重要な変更<!-- Important -->:
   
@@ -77,7 +77,7 @@ content: |-
   -->
   これらの stable の修正は 31 名のコントリビュータによってなされました。
   
-  ### ダウンロード<!-- Downloads -->
+  # ダウンロード<!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.3.

--- a/content/lxc/news.ja/lxc-1.1.4.yaml
+++ b/content/lxc/news.ja/lxc-1.1.4.yaml
@@ -78,7 +78,7 @@ content: |-
   -->
   これらの stable の修正は 14 名のコントリビュータによってなされました。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.4.

--- a/content/lxc/news.ja/lxc-1.1.5.yaml
+++ b/content/lxc/news.ja/lxc-1.1.5.yaml
@@ -32,7 +32,7 @@ content: |-
    * ubuntu-cloud: デフォルトで tar.xz tarball を使うようになりました (tar.gz はすぐに廃止される予定です) <!-- Use tar.xz tarballs by default (as tar.gz will soon be discontinued) -->
    * ubuntu-cloud: エラー時は常に終了コード 1 で終了するようになりました <!-- Always exit 1 on error -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.5.

--- a/content/lxc/news.ja/lxc-2.0.0.yaml
+++ b/content/lxc/news.ja/lxc-2.0.0.yaml
@@ -6,7 +6,7 @@ content: |-
   -->
   LXC チームは LXC 2.0 のリリースをお知らせできることをうれしく思います！
   
-  ### ハイライト <!-- Highlights -->
+  # ハイライト <!-- Highlights -->
   
    * 主要な LXC コマンドはすべて C 言語で書きなおされました <!-- All main LXC commands have now been rewritten in C -->
       * lxc-ls
@@ -25,7 +25,7 @@ content: |-
   -->
   このリリースは合計 96 名のコントリビュータからの 720 コミットからなる貢献によってリリースできました。
   
-  ### 新しい設定オプション <!-- New configuration options -->
+  # 新しい設定オプション <!-- New configuration options -->
   
    * lxc.ephemeral: コンテナが一時的 (ephemeral) かどうかをコントロールします。一時的な場合はシャットダウン後に削除されます <!-- Controls whether the container is ephemeral and so will be destroyed on shutdown -->
    * lxc.rebootsignal: コンテナをリブートするために送出するシグナルを指定できます <!-- Allows to override the signal sent for container reboot -->
@@ -35,7 +35,7 @@ content: |-
    * lxc.init\_gid: lxc-execute が使うグループを指定します <!-- Used by lxc-execute to set an alternative group -->
    * lxc.monitor.unshare: 他のフックを実行する前にマウント名前空間を unshare できます <!-- Allows unsharing the mount namespace prior to running any hook -->
   
-  ### 新機能 <!-- New features -->
+  # 新機能 <!-- New features -->
   
    * API:
       * API バージョンは 1.2 です。1.0、1.1 に対する完全な後方互換性を保っています <!-- API version is 1.2, fully backward compatible with 1.1 and 1.0 -->
@@ -87,7 +87,7 @@ content: |-
       * ubuntu: ユーザが debootstrap の variant を指定できるように -v オプションを追加しました <!-- New -v option allowing the user to set the debootstrap variant -->
       * ubuntu-cloud: vendor-data を指定できるようになりました <!-- Support for vendor-data passthrough -->
   
-  ### 挙動の変更 <!-- Change in behavior -->
+  # 挙動の変更 <!-- Change in behavior -->
   
    * lxc-autostart の起動順が逆になりました (正しい動きになりました) (訳注: lxc.start.order に指定した値の降順で起動していたのが昇順になった)<!-- The lxc-autostart container startup order is now reversed (to be correct) -->
    * cgfsng cgroup バックエンドが推奨のバックエンドになりました <!-- The new cgfsng cgroup backend is now the recommended backend -->
@@ -102,7 +102,7 @@ content: |-
   我々は、コマンドラインツールは stable な ABI とはみなしていませんので、ご自身のスクリプトをテストして変更する必要があるかもしれません。
   そのスクリプトを、LXC の stable な C API か、言語バインディングのどれかを使って書きなおすのがよりベターでしょう。
   
-  ### 廃止予定の警告 <!-- Deprecation warnings -->
+  # 廃止予定の警告 <!-- Deprecation warnings -->
   
   <!--
   The "lxc-clone" and "lxc-start-ephemeral" commands are now considered deprecated and to be replaced by the new lxc-copy.
@@ -112,7 +112,7 @@ content: |-
   "lxc-clone" と "lxc-start-ephemeral" コマンドは、"lxc-copy" に置き換えられ、将来廃止の予定です。
   これらのコマンドは --enable-legacy フラグを使ってビルドできますが、使用の際に警告が表示されます。そして、LXC の将来のリリースで削除される予定です。
   
-  ### サポート <!-- Support -->
+  # サポート <!-- Support -->
   <!--
   This is the second LXC Long Term Support release which we will be supporting until the 1st of June 2021.
   LXC 1.0, our previous Long Term Support release, is still supported until the 1st of June 2019.
@@ -122,7 +122,7 @@ content: |-
   前の長期サポートリリース版である LXC 1.0 も、2019 年 6 月 1 日までサポートされます。
   そして、先の stable リリースである LXC 1.1 は 2016 年 9 月 1 日に EOL となります。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.0.

--- a/content/lxc/news.ja/lxc-2.0.1.yaml
+++ b/content/lxc/news.ja/lxc-2.0.1.yaml
@@ -48,7 +48,7 @@ content: |-
    * templates: ホスト名を送信するために Alpine の DHCP 設定を調整しました <!-- tweak Alpine DHCP configuration to send its hostname -->
    * templates: Oracle テンプレートのネットワーク設定を調整しました <!-- tweak to network configuration of the Oracle template -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.1.

--- a/content/lxc/news.ja/lxc-2.0.11.yaml
+++ b/content/lxc/news.ja/lxc-2.0.11.yaml
@@ -18,21 +18,21 @@ content: |-
   -->
   以下の変更点は 2.0.9 から 2.0.11のものすべてです。
 
-  ### セキュリティ上の修正 <!-- Security fixes -->
-  #### CVE-2018-6556 の修正<!-- Fixes CVE-2018-6556 -->
+  # セキュリティ上の修正 <!-- Security fixes -->
+  ## CVE-2018-6556 の修正<!-- Fixes CVE-2018-6556 -->
   <!--
   `lxc-user-nic` when asked to delete a network interface would unconditionally open a user provided path. This code path could be used by an unprivileged user to check for the existence of a path which they wouldn't otherwise be able to reach. It may also be used to trigger side effects by causing a (read-only) open of special kernel files (ptmx, proc, sys). For more details see [here](https://nvd.nist.gov/vuln/detail/CVE-2018-6556).
   -->
   `lxc-user-nic` がネットワークインターフェースを削除するような要求を受けたとき、ユーザーが与えたパスを無条件に open します。このコードが、非特権ユーザーが他の方法では到達できないパスの存在をチェックするのに使われる可能性がありました。特別なカーネルファイル（ptmx、proc、sys）を（読み取り専用で） open することで副作用を引き起こすのに使われる可能性もあります。詳しくは [CVE-2018-6556](https://nvd.nist.gov/vuln/detail/CVE-2018-6556) をご覧ください。
 
-  #### CVE-2019-5736 の修正 <!-- Fixes CVE-2019-5736 -->
+  ## CVE-2019-5736 の修正 <!-- Fixes CVE-2019-5736 -->
   <!--
   This release fixes [CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736). It is a major security issue afflicting all container runtimes and is exploitable when attaching to privileged containers. More details on the the bug and how it is fixed can be found [here](https://brauner.github.io/2019/02/12/privileged-containers.html).
   -->
   [CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) を修正しました。この問題は、すべてのコンテナランタイムを苦しめる大きなセキュリティ上の問題で、特権を持つコンテナにアタッチする際に悪用されます。バグの詳細とそれをどのように修正するかは [このページ](https://brauner.github.io/2019/02/12/privileged-containers.html) で読むことができます。
 
-  ### 主なバグ修正 <!-- Main bugfixes -->
-  #### 設定ファイルのないコンテナを扱えるようになりました <!-- Allow attaching to undefined containers -->
+  # 主なバグ修正 <!-- Main bugfixes -->
+  ## 設定ファイルのないコンテナを扱えるようになりました <!-- Allow attaching to undefined containers -->
 
   <!--
   For example the following sequence is now expected to work:
@@ -45,82 +45,82 @@ content: |-
       -s 'lxc.rootfs = /path/to/rootfs' \
       -s 'lxc.init_cmd = /path/to/initcmd'
 
-  #### アタッチの際に正しい名前空間の継承処理を行うようになりました <!-- Correctly handle namespace inheritance in attach -->
+  ## アタッチの際に正しい名前空間の継承処理を行うようになりました <!-- Correctly handle namespace inheritance in attach -->
 
   <!--
   `lxc_attach` will now correctly distinguish between a caller specifying specific namespaces to attach to and a caller not requesting specific namespaces. The latter is taken by `lxc_attach` to mean that all namespaces will be attached. This also needs to include all inherited namespaces.
   -->
   `lxc_attach` が、アタッチするために特定の名前空間を指定する呼び出し元と、特定の名前空間を要求しない呼び出し元を正しく区別するようになりました。後者は、すべての名前空間にアタッチされるという意味に `lxc_attach` が処理します。これにはすべての継承した名前空間を含める必要があります。
 
-  #### `testing` と `unstable` の Debian コンテナが作成できるようになりました <!-- Allow the creation of `testing` and `unstable` Debian containers -->
+  ## `testing` と `unstable` の Debian コンテナが作成できるようになりました <!-- Allow the creation of `testing` and `unstable` Debian containers -->
   
   <!--
   Being able to create `testing` containers, regardless of what's the name of the next stable, is useful in several contexts, included but not limited to testing purposes. i.e. one won't need to explicitly switch to `bullseye` once `buster` is released to be able to continue tracking `testing`. While we are at it, let's also enable `unstable`, which is exactly the same as `sid`, but there is no reason for not being able to.
   -->
   次の stable の名前に関わらず `testing` のコンテナを作成できることは、テスト用途を含むがそれに限らない、いくつかの状況で役立ちます。すなわち、`buster` がリリースされても、明示的に `bullseye` に切り替える必要がないということは、ずっと `testing` を追跡し続けることができるということです。そのように行った上で、`unstable` （これは `sid` と同じです）も有効にしてみましょう。これも同様にできるでしょう。
 
-  #### `CAP_SYS_ADMIN` なしのコンテナが可能になりました（cgroup の扱いに関係する）<!-- Enable container without `CAP_SYS_ADMIN` (cgroup handling) -->
+  ## `CAP_SYS_ADMIN` なしのコンテナが可能になりました（cgroup の扱いに関係する）<!-- Enable container without `CAP_SYS_ADMIN` (cgroup handling) -->
 
   <!--
   In case cgroup namespaces are supported but we do not have `CAP_SYS_ADMIN` we need to mount cgroups for the container. This patch enables both privileged and unprivileged containers without `CAP_SYS_ADMIN`.
   -->
   cgroup 名前空間がサポートされているけれども `CAP_SYS_ADMIN` を持っていない場合、コンテナのために（訳注: LXC が） cgroup をマウントする必要があります。`CAP_SYS_ADMIN` を持たない特権、非特権コンテナの両方で可能になります。
 
-  #### `cgroup2` の扱いの改良 <!-- Improved `cgroup2` handling -->
+  ## `cgroup2` の扱いの改良 <!-- Improved `cgroup2` handling -->
   <!--
   Since cgroup2 is becoming more common LXC 2.0.11 comes with a wide range of improvements in that area.
   -->
   cgroup2 がより一般的になってきているので、LXC 2.0.11 では cgroup2 に関して広く改良がなされています。
 
-  #### cgroup の read-only マウントのサポート <!-- Support read-only mounts of cgroups -->
+  ## cgroup の read-only マウントのサポート <!-- Support read-only mounts of cgroups -->
   <!--
   This is especially useful if the container lacks `CAP_SYS_ADMIN` and thus cannot remount.
   -->
   これは、コンテナに `CAP_SYS_ADMIN` がなくて、そのため再マウントができない場合に特に便利な機能です。
 
-  #### `SIGTERM` を使ってコンソールから exit できるようになりました <!-- Allow to exit from console via `SIGTERM` -->
+  ## `SIGTERM` を使ってコンソールから exit できるようになりました <!-- Allow to exit from console via `SIGTERM` -->
   <!--
   This allows cleanly exiting a console session without control sequences. Instead `SIGTERM` can be sent to the affected process and it will cause LXC to cleanly terminate the console session.
   -->
   これにより、コントロールシーケンスなしでコンソールセッションからきれいに exit できます。代わりに `SIGTERM` を対象のプロセスに送ると、LXC はきれいにコンソールセッションを終了させます。
 
-  #### アプリケーションコンテナの実行時に与える引数の数を正しく計算するようになりました <!-- Correctly calculate the number of arguments passed when running application containers -->
+  ## アプリケーションコンテナの実行時に与える引数の数を正しく計算するようになりました <!-- Correctly calculate the number of arguments passed when running application containers -->
   <!--
   The number of arguments passed to `exec` was miscalculated under certain conditions. This release ensure that the correct number of arguments is calculated and passed to `exec.`
   -->
   `exec` に渡す引数の数を、特定の条件下で間違って計算していました。このリリースで確実に正しく引数の数を計算し、`exec` に渡すようになりました。
 
-  #### コード全体から不要なロックを削除しました <!-- Remove all unneeded locking from the codebase -->
+  ## コード全体から不要なロックを削除しました <!-- Remove all unneeded locking from the codebase -->
   <!--
   Older version of LXC used mutexes in various places to ensure thread-safety. Careful redesign of these codepaths has enabled us to remove all mutextes from the codebase. This has led to simplifications and speedups for various operations such as container start and stop.
   -->
   古いバージョンの LXC はスレッドセーフを保証するために、色々な場所で mutex を使っていました。これらのコードパスを注意深く再デザインすることで、コードからすべての mutex を削除できました。これにより、簡略化が行え、コンテナの起動や停止のような様々な操作でスピードアップが図れました。
 
-  #### cgroup 名前空間の保護の問題を修正しました <!-- Fix cgroup namespace preservation -->
+  ## cgroup 名前空間の保護の問題を修正しました <!-- Fix cgroup namespace preservation -->
   <!--
   This eliminates a race and makes sure that the cached file descriptor refers to the container's cgroup namespace and not to the hosts'.
   -->
   これにより競合が取り除かれ、キャッシュされたファイルディスクリプタが、ホストでなく確実にコンテナの cgroup 名前空間を参照するようになります。
 
-  #### アプリケーションがホストの PID 名前空間を共有できるようになりました <!-- Allow application to share the hosts' pid namespace -->
+  ## アプリケーションがホストの PID 名前空間を共有できるようになりました <!-- Allow application to share the hosts' pid namespace -->
   <!--
   Prior versions of LXC did not allow to share the hosts' pid namespace. Starting with this bugfix release it is possible to do this correctly.
   -->
   以前のバージョンの LXC は、ホストの PID 名前空間を共有できませんでした。このバグ修正リリース以降、これを正しく行うことができます。
 
-  #### 非常に寿命が短いアプリケーションコンテナを正しく扱うようになりました <!-- Correctly handle very short-lived application containers -->
+  ## 非常に寿命が短いアプリケーションコンテナを正しく扱うようになりました <!-- Correctly handle very short-lived application containers -->
   <!--
   Prior versions had trouble to correctly handle extremely short-lived application containers. For example, LXC could incorrectly report that a container is still running when it had already shut down due to a TOCTU and refuse to restart it. This caused unnecessary delay. Also, output of such short-lived containers written to stdout could get lost or truncated. This release fixes both issues.
   -->
   これまでのバージョンでは、極端に寿命が短いアプリケーションコンテナを正しく処理するのが困難でした。例えば LXC は TOCTOU が原因で、コンテナがすでにシャットダウンしていてもまだ実行中であると誤って報告し、再起動を拒否する可能性がありました。これは不要な遅延を引き起こします。そして、このような寿命の短いコンテナの出力が stdout に書かれると、出力が失われたり切り詰められたりする可能性がありました。このリリースでこれらの問題を修正しました。
 
-  #### `hidepid=1` か `hidepid=2` でマウントされたコンテナを正しく処理するようになりました <!-- `/proc` Correctly handle containers where `/proc` has been mount with `hidepid=1` or `hidepid=2` -->
+  ## `hidepid=1` か `hidepid=2` でマウントされたコンテナを正しく処理するようになりました <!-- `/proc` Correctly handle containers where `/proc` has been mount with `hidepid=1` or `hidepid=2` -->
   <!--
   In prior versions attaching to unprivileged containers as an unprivileged user with `/proc` mounted with `hidepid=1` or `hidepid=2` would fail since LXC could not retrieve needed information from `/proc`. This is now fixed.
   -->
   これまでのバージョンでは、`hidepid=1` もしくは `hidepid=2` でマウントされた `/proc` を持つ非特権コンテナに非特権ユーザーとしてアタッチすると、LXC は必要な情報を `/proc` から取得できないため失敗していました。これを修正しました。
 
-  #### cgroup 名前空間がサポートされている場合でも、強制的に cgroup をマウントできるようになりました <!-- Allow to force mount cgroups even when cgroup namespaces are supported -->
+  ## cgroup 名前空間がサポートされている場合でも、強制的に cgroup をマウントできるようになりました <!-- Allow to force mount cgroups even when cgroup namespaces are supported -->
   <!--
   This lets users specify `lxc.mount.auto = cgroup:mixed:force` or `lxc.mount.auto = cgroup:ro:force` or `lxc.mount.auto = cgroup:rw:force`.
   -->
@@ -156,7 +156,7 @@ content: |-
     - read-only cgroup:
       例えば、アプリケーションに自身が所属する cgroup の内部を見せつつ、コンテナ内から cgroup の制限を変更するのを防ぐには cgroup を read-only でマウントすることができれば便利です。これもアプリケーションコンテナには便利です。systemd が動作しているシステムコンテナは、通常は cgroup が read-only でマウントされていると動作しません。
 
-  #### その他のバグフィックス <!-- Everything else -->
+  ## その他のバグフィックス <!-- Everything else -->
   <!--
   2.0.11 includes almost a year and a half of bugfixes cherry-picked from current LXC, the entire list can be found below.
   -->
@@ -791,7 +791,7 @@ content: |-
 
 
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](https://linuxcontainers.org/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.11.

--- a/content/lxc/news.ja/lxc-2.0.2.yaml
+++ b/content/lxc/news.ja/lxc-2.0.2.yaml
@@ -34,7 +34,7 @@ content: |-
    * travis: VPATH ビルドのテストを行うようにしました <!-- test VPATH builds -->
    * upstart: lxc-instance を Upstart クライアントとして適した形に変更しました <!-- Force lxc-instance to behave like a good Upstart client -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.2.

--- a/content/lxc/news.ja/lxc-2.0.3.yaml
+++ b/content/lxc/news.ja/lxc-2.0.3.yaml
@@ -19,7 +19,7 @@ content: |-
   
    * apparmor: 生成されたファイルの更新 <!-- Refresh generated file -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.3.

--- a/content/lxc/news.ja/lxc-2.0.4.yaml
+++ b/content/lxc/news.ja/lxc-2.0.4.yaml
@@ -48,7 +48,7 @@ content: |-
    * tests: lxc\_string\_in\_array() に対するユニットテストを追加しました <!-- Add unit tests for lxc\_string\_in\_array() -->
    * tests: lxc\_string\_replace() に対するユニットテストを追加しました <!-- Add unit tests for lxc\_string\_replace() -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.4.

--- a/content/lxc/news.ja/lxc-2.0.5.yaml
+++ b/content/lxc/news.ja/lxc-2.0.5.yaml
@@ -75,7 +75,7 @@ content: |-
    * 開発リリースであることが検出できるように LXC\_DEVEL を定義しました <!-- Define LXC\_DEVEL to detect development releases -->
    * tools: lxc-checkconfig の devpts のチェックを条件付きとしました (訳注: kernel 4.7 で DEVPTS_MULTIPLE_INSTANCES が削除されたので < 4.7 の時のみチェックするようになった)<!-- lxc-checkconfig conditionalize devpts check -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.5.

--- a/content/lxc/news.ja/lxc-2.0.6.yaml
+++ b/content/lxc/news.ja/lxc-2.0.6.yaml
@@ -119,7 +119,7 @@ content: |-
    * tests: overflow のテストを削除しました <!-- remove overflow tests -->
    * attach: attach するプロセスに procfd を送らないようにしました <!-- do not send procfd to attached process -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.6.

--- a/content/lxc/news.ja/lxc-2.0.7.yaml
+++ b/content/lxc/news.ja/lxc-2.0.7.yaml
@@ -68,7 +68,7 @@ content: |-
    * utils: \_\_LXC\_NUMSTRLEN マクロを追加しました <!-- Add macro \_\_LXC\_NUMSTRLEN -->
    * utils: uid, gid, group を扱うのに便利なラッパー関数を追加しました <!-- Add uid, gid, group convenience wrappers -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.7.

--- a/content/lxc/news.ja/lxc-2.0.8.yaml
+++ b/content/lxc/news.ja/lxc-2.0.8.yaml
@@ -116,7 +116,7 @@ content: |-
    * (訳注: configure で) `ubuntu` と `debian` の case をマージしました <!-- Merge `ubuntu` and `debian`case -->
    * start: lxc\_spawn() に重要なコメントを追加しました <!-- add crucial details about lxc\_spawn() -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.8.

--- a/content/lxc/news.ja/lxc-2.0.9.yaml
+++ b/content/lxc/news.ja/lxc-2.0.9.yaml
@@ -280,7 +280,7 @@ content: |-
    * utils: オーバーフローしてしまうので 1LU を使うようにしました <!-- Use 1LU otherwise we overflow -->
    * utils: stat の代わりに access を使うようにしました <!-- Use access instead of stat -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.9.

--- a/content/lxc/news.ja/lxc-2.1.1.yaml
+++ b/content/lxc/news.ja/lxc-2.1.1.yaml
@@ -69,7 +69,7 @@ content: |-
    * utils: <!-- Fix -->lxc\_popen()/lxc\_pclose() を修正しました
    * utils: lxc\_popen() 内の不要な変数割り当てを削除しました <!-- Remove dead assignments in lxc\_popen() -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.1.1.

--- a/content/lxc/news.ja/lxc-2.1.yaml
+++ b/content/lxc/news.ja/lxc-2.1.yaml
@@ -14,8 +14,8 @@ content: |-
   -->
   このリリースは LTS リリースではないことに注意してください。LTS リリースではありませんので、LXC 2.1 のサポートは 1 年間のみです。長い期間のサポートが必要なプロダクション環境では 2021 年 6 月までサポートされる LXC 2.0 を使い続けてください。
   
-  ## 新機能 <!-- New features -->
-  ### リソース制限のサポート<!-- Resource limit support -->
+  # 新機能 <!-- New features -->
+  ## リソース制限のサポート<!-- Resource limit support -->
   <!--
   Similar to requesting specific cgroup limits users can specify any limits for any resource
   the underlying kernel is aware of by prefixing the name of the limit with "lxc.prlimit."
@@ -27,7 +27,7 @@ content: |-
       lxc.prlimit.nproc = unlimited
       lxc.prlimit.nice = 4
   
-  ### 非特権での Open vSwitch ネットワークのサポート <!-- Support for unprivileged openvswitch networks -->
+  ## 非特権での Open vSwitch ネットワークのサポート <!-- Support for unprivileged openvswitch networks -->
   <!--
   It is now possible to define openvswitch networks as an unprivileged user:
   -->
@@ -44,7 +44,7 @@ content: |-
   -->
   LXC 2.1 は、シャットダウン時に openvswitch からホスト側の veth デバイスを適切に削除する処理を行います。
   
-  ### 新たな設定項目 `lxc.cgroup.dir` <!-- New `lxc.cgroup.dir` key -->
+  ## 新たな設定項目 `lxc.cgroup.dir` <!-- New `lxc.cgroup.dir` key -->
   <!--
   The `lxc.cgroup.dir` key lets users specify the name of the parent cgroup under
   which the container's cgroup will be created. Setting `lxc.cgroup.dir` will
@@ -58,7 +58,7 @@ content: |-
   -->
   例えば、`lxc.uts.name = c1` と設定されたコンテナに `lxc.cgroup.dir = mycontainers` と設定すると、LXC は cgroup 階層内のすべてのコントローラで、`mycontainers/c1` という cgroup を作ります。
   
-  ### hybrid cgroup レイアウトのサポート <!-- Support for hybrid cgroup layout -->
+  ## hybrid cgroup レイアウトのサポート <!-- Support for hybrid cgroup layout -->
   <!--
   Since the advent of cgroup v2 some init systems have decided to allow for a hybrid mode in which
   cgroup v1 per-controller hierarchies can be used simultaneously with an empty cgroup v2 hierarchy.
@@ -78,7 +78,7 @@ content: |-
   -->
   マウントポイント `/sys/fs/cgroup/unified` は、通常は cgroup v2 階層の存在を示します。これは `findmnt | grep cgroup2` が一致する行を返すかどうかをテストすることで確認できます。LXC 2.1 はこの hybrid モードをサポートします。
   
-  ### コンテナが割り当てることができる pty の数を制限する <!-- Limiting the number of ptys a container can allocate -->
+  ## コンテナが割り当てることができる pty の数を制限する <!-- Limiting the number of ptys a container can allocate -->
   <!--
   Setting `lxc.pty.max` will cause LXC to mount the container's devpts with the requested limit
   on the number of usable ptys. For example, setting `lxc.pty.max = 10` will only allow
@@ -86,7 +86,7 @@ content: |-
   -->
   `lxc.pty.max` を設定すると、LXC は、使える pty の数に指定した制限を設定した上で、コンテナの devpts をマウントします。例えば、`lxc.pty.max = 10` と設定すると、コンテナは `10` 個の pty だけしか割り当てられません。デフォルト値は `1024` です。
   
-  ### `bool lxc_config_item_is_supported(const char *key)` API 拡張 <!-- extension -->
+  ## `bool lxc_config_item_is_supported(const char *key)` API 拡張 <!-- extension -->
   <!--
   This function let's users query the liblxc whether a specific configuration item is supported for this library.
   This is particularly useful for embedded users that running versions of liblxc that come with significantly
@@ -95,7 +95,7 @@ content: |-
   この関数は、特定の設定項目がライブラリでサポートされているかどうかをユーザが問い合わせるための関数です。この関数は、標準的な liblxc ライブラリや、新しい設定項目がバックポートされた liblxc よりもはるかに少ない設定オプションを持つ liblxc のバージョンを実行する組み込みユーザに特に役に立つでしょう。
   
   
-  ### 新しいログ API 拡張 <!-- New log API extension -->
+  ## 新しいログ API 拡張 <!-- New log API extension -->
   
       struct lxc_log {
           const char *name;
@@ -123,7 +123,7 @@ content: |-
   -->
   上記の構造体や関数は、ユーザが LXC のロギングを初期化できるようにするためのものです。liblxc の API を直接使うユーザには役に立つでしょう。
   
-  ### `lxc-monitord` が廃止予定に <!-- Deprecation of `lxc-monitord` -->
+  ## `lxc-monitord` が廃止予定に <!-- Deprecation of `lxc-monitord` -->
   <!--
   Starting with LXC 2.1 the `lxc-monitord` binary is marked as deprecated.
   It is not required anymore to start daemonized containers. Instead, LXC 2.1 switches to an implementation using
@@ -137,7 +137,7 @@ content: |-
   -->
   また、重い負荷で行った新しい実装のテストで、このソリューションがより堅牢で信頼性が高いことがわかりました。
   
-  ### `lxc-copy` は `tmpfs` 上にスナップショットを作ります <!-- `lxc-copy` create snapshots on `tmpfs` -->
+  ## `lxc-copy` は `tmpfs` 上にスナップショットを作ります <!-- `lxc-copy` create snapshots on `tmpfs` -->
   <!--
   Place an ephemeral container started with -e flag on a tmpfs.
   Restrictions are that you cannot request the data to be kept while placing the container on a tmpfs,
@@ -185,7 +185,7 @@ content: |-
   これで、通常のクローン処理での正確な動作をリストアするために必要なことすべてのはずです。
   注: もしコンテナを再起動した場合、すべての変更は失われます。リブートごとに rootfs が再度マウントされますので、これを防ぐのは容易ではありません。
   
-  ## 設定項目名の変更 <!-- Configuration changes -->
+  # 設定項目名の変更 <!-- Configuration changes -->
   <!--
   A lot of configuration keys have been renamed to make the experience of configuring a container much more consistent.
   LXC 2.1 ensures that all keys that have subkeys are properly namespaces via the "." syntax.
@@ -193,7 +193,7 @@ content: |-
   コンテナの設定がより一貫性を持って行えるように、多数の設定項目の名前が変わりました。
   LXC 2.1 では、すべての設定項目が "." で分けられた適切なネームスペースから構成されるサブキーを持つようになりました。
   
-  ### ネットワーク設定 <!-- Network configuration -->
+  ## ネットワーク設定 <!-- Network configuration -->
   <!--
   The network configuration keys have all been given a new prefix. Some of them  have also been renamed.
   From LXC 2.1. onwards network configuration keys using the "lxc.network" prefix are considered deprecated.
@@ -264,7 +264,7 @@ content: |-
   -->
   上のような設定では、LXC は、最後の設定が `virbr0` に設定されているため、ネットワークは `virbr0` に関連付けられます。
   
-  ### 変更された設定項目一覧 <!-- Table of changed configuration keys -->
+  ## 変更された設定項目一覧 <!-- Table of changed configuration keys -->
   <!--
   The following table lists the legacy configuration keys on the left side and their corresponding new keys on the right side. Keys that have been entirely removed will have "-" as entry in the "New Key" column and a comment saying "removed" in the "Comments" table.
   -->
@@ -314,7 +314,7 @@ content: |-
       lxc.tty                              | lxc.tty.max                   |
       lxc.utsname                          | lxc.uts.name                  |
   
-  ### `lxc-update-config` スクリプト <!-- script -->
+  ## `lxc-update-config` スクリプト <!-- script -->
   <!--
   LXC 2.1 comes with a new script `lxc-update-config` which can be used to upgrade existing legacy
   LXC configurations to valid LXC 2.1 configurations by simply passing
@@ -334,7 +334,7 @@ content: |-
   バックアップファイルは、万が一、アップグレードで生成した設定ファイルが LXC 2.1 で使えないのに備えて作成します。
   バックアップを生成したあと、スクリプトが以前の設定が新しい設定に置き換えます。
   
-  ## 廃止予定の警告 <!-- Deprecation warnings -->
+  # 廃止予定の警告 <!-- Deprecation warnings -->
   <!--
   LXC 2.1 intends to be fully backward compatible with respect to pre-2.1 configuration files.
   This specifically means that the presence of any deprecated keys should not prevent the container from being usable.

--- a/content/lxc/news.ja/lxc-3.0.0.yaml
+++ b/content/lxc/news.ja/lxc-3.0.0.yaml
@@ -3,7 +3,7 @@ date: 2018/03/27 00:00
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-0-has-been-released/1449
 content: |-
   
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 3.0.0!
   -->
@@ -16,8 +16,8 @@ content: |-
   このリリースは LXC 2.1.0 のリリース以来 6 ヶ月に及ぶ集中した作業の成果で、LXC プロジェクトの 3 つ目の LTS リリースとなります。そして、2023 年までサポートされます。
   
   
-  ### 主な変更点 <!-- Major changes -->
-  #### すべてのコマンドでの `lxc-start <コンテナ名>` という文法のサポート <!-- All commands support `lxc-start <container-name>` syntax -->
+  # 主な変更点 <!-- Major changes -->
+  ## すべてのコマンドでの `lxc-start <コンテナ名>` という文法のサポート <!-- All commands support `lxc-start <container-name>` syntax -->
   
   <!--
   The LXC tools now support passing the container name without the `-n` command line flag. For example, you can now run:
@@ -46,7 +46,7 @@ content: |-
       chb@conventiont|~
       > lxc-stop xenial
   
-  #### すべてのレガシーな設定項目の削除 <!-- Removed support for all legacy configuration keys -->
+  ## すべてのレガシーな設定項目の削除 <!-- Removed support for all legacy configuration keys -->
   <!--
   All legacy configuration keys are unsupported from LXC 3.0 onwards.
   The full list of deprecated keys and their new counterparts can be gathered from the [LXC 2.1 release announcement](https://discuss.linuxcontainers.org/t/lxc-2-1-has-been-released/487).
@@ -59,7 +59,7 @@ content: |-
   -->
   `lxc-update-config` ツールを使って、古い無効な設定を新しいフォーマットに変換できます。
   
-  #### リソース制限を含む単一階層の cgroup のフルサポート <!-- Full support for the unified cgroup hierarchy including resource limits -->
+  ## リソース制限を含む単一階層の cgroup のフルサポート <!-- Full support for the unified cgroup hierarchy including resource limits -->
   <!--
   We are pleased to announce that LXC will fully support the new unified cgroup hierarchy (or cgroup v2, cgroup2). To this end we also introduced a new configuration key `lxc.cgroup2.[controller name]` to configure cgroup limits on the unified cgroup hierarchy.
   For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/19/lxc-lands-unified-cgroup-hierarchy-support.html).
@@ -67,13 +67,13 @@ content: |-
   LXC が、新しい単一階層構造の cgroup (cgroup v2、cgroup2) を完全にサポートしました。この機能を使い、単一階層構造の cgroup で制限を設定するために、`lxc.cgroup2.[コントローラ名]` という設定項目を追加しました。
   さらに詳しい情報を得るには、["LXC Lands Unified cgroup Hierarchy Support"](https://brauner.github.io/2018/02/19/lxc-lands-unified-cgroup-hierarchy-support.html) というブログポストをご覧ください。
   
-  #### レガシーな cgmanager、cgfs cgroup ドライバの削除 <!-- Removal of legacy cgmanager and cgfs cgroup drivers -->
+  ## レガシーな cgmanager、cgfs cgroup ドライバの削除 <!-- Removal of legacy cgmanager and cgfs cgroup drivers -->
   <!--
   LXC removed the `cgmanager` and `cgfs` legacy cgroup drivers cleaning up a lot of code in the process. For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/20/lxc-removes-legacy-cgroup-drivers.html).
   -->
   LXC から、`cgmanager` と `cgfs` というレガシーな cgroup ドライバを削除し、多数のコードを削除しました。さらに詳しい情報を得るには、["On The Way To LXC 3.0: Removal of cgmanager And cgfs cgroup Drivers"](https://brauner.github.io/2018/02/20/lxc-removes-legacy-cgroup-drivers.html) というブログポストをご覧ください。
   
-  #### テンプレートと言語バインディングの分離 <!-- Splitting out templates and language bindings -->
+  ## テンプレートと言語バインディングの分離 <!-- Splitting out templates and language bindings -->
   <!--
   LXC removes the legacy template-based container build system in favor of the new project [distrobuilder](https://github.com/lxc/distrobuilder). For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/27/lxc-removes-legacy-template-build-system.html).
   -->
@@ -94,7 +94,7 @@ content: |-
    - lxc-local (ローカルでビルドされたイメージをインポートする (例えば distrobuilder などで)) <!-- (import locally build images (e.g. from distrobuilder)) -->
    - lxc-oci (OCI アプリケーションコンテナイメージを使う) <!-- (use OCI application container images) -->
   
-  #### cgroup PAM モジュールの LXC ツリーへの移動 <!-- Moving the cgroup PAM module into the LXC tree -->
+  ## cgroup PAM モジュールの LXC ツリーへの移動 <!-- Moving the cgroup PAM module into the LXC tree -->
   <!--
   LXC has always supported fully unprivileged containers, i.e. unprivileged containers run by unprivileged users. An important piece in doing so was a PAM module that created writable cgroups for unprivileged users. This has been moved from the LXCFS tree into the LXC tree itself to make it even easier for users to run fully unprivileged containers.
   For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/28/lxc-includes-cgroup-pam-module.html).
@@ -102,7 +102,7 @@ content: |-
   LXC は常に非特権コンテナを完全にサポートしてきています。非特権コンテナは特権を持たないユーザが実行します。この実行を行うための重要な要素が、特権を持たないユーザが書き込み権を持つ cgroup を作成する PAM モジュールでした。この PAM モジュールが LXCFS から LXC に移されました。これにより、ユーザが完全に非特権のコンテナをさらに簡単に実行できるようになりました。
   さらに詳細な情報を得るには、["On The Way To LXC 3.0: Moving The Cgroup Pam Module Into The LXC Tree (Including A Detour About Fully Unprivileged Containers)"](https://brauner.github.io/2018/02/28/lxc-includes-cgroup-pam-module.html) というブログポストをご覧ください。
   
-  #### 新しい `OCI` テンプレートの追加 <!-- New `OCI` template -->
+  ## 新しい `OCI` テンプレートの追加 <!-- New `OCI` template -->
   <!--
   This adds support for creating application containers from OCI formats. 
   Examples:
@@ -128,7 +128,7 @@ content: |-
   -->
   URL は `skopeo copy` と同じ形式で指定します。
   
-  #### コンソールのロギング用のシンプルで効率的なリングバッファ <!-- Simple and efficient ringbuffer for console logging -->
+  ## コンソールのロギング用のシンプルで効率的なリングバッファ <!-- Simple and efficient ringbuffer for console logging -->
   <!--
   LXC supports logging the container's console to a file. This had the unfortunate side effect of allowing a user in the container to effectively write as much data as they wanted on the host, possibly bypassing quotas in place for the container.
   -->
@@ -144,7 +144,7 @@ content: |-
   -->
   LXC 3.0 ではコンソールロギングにリングバッファが導入されました。このメモリ内のバッファはサイズ制限があり、LXC API の新しい関数で照会できます。いつでもリセットでき、コンテナのシャットダウン時にダンプすることもできます。
   
-  #### seccomp の引数を使ったシステムコールのフィルタ <!-- Allow seccomp to filter syscalls based on arguments -->
+  ## seccomp の引数を使ったシステムコールのフィルタ <!-- Allow seccomp to filter syscalls based on arguments -->
   <!--
   In order to support filtering syscalls based on arguments the `seccomp` version `2` specification is extended to the following form:
   -->
@@ -197,102 +197,102 @@ content: |-
       unshare errno 9 [0,0x10000000,SCMP_CMP_EQ]
       unshare errno 2 [0,0x20000000,SCMP_CMP_EQ]
   
-  #### アプリケーションコンテナのデーモン化のサポート <!-- Support for daemonized app containers -->
+  ## アプリケーションコンテナのデーモン化のサポート <!-- Support for daemonized app containers -->
   <!--
   This enables daemonized application containers with our minimal init running as pid one and the requested program running as second pid.
   -->
   
   最小限の動きをする init を pid 1 で実行し、指定したプログラムを pid 2 で実行するアプリケーションコンテナを、デーモンとして起動できるようになりました。
   
-  #### `lxc-*` ツールからのすべての内部シンボルの削除 <!-- Remove all internal symbols from `lxc-*` tools -->
+  ## `lxc-*` ツールからのすべての内部シンボルの削除 <!-- Remove all internal symbols from `lxc-*` tools -->
   <!--
   The `lxc-*` tools now only entirely rely on the public LXC API.
   -->
   `lxc-*` ツールは、もっぱら公開された LXC API にのみ、依存するようになりました。
   
-  #### `hidepid={1,2}` プロパティを使ってマウントされた `/proc` の扱い <!-- Handle `/proc` being mounted with the `hidepid={1,2}` property -->
+  ## `hidepid={1,2}` プロパティを使ってマウントされた `/proc` の扱い <!-- Handle `/proc` being mounted with the `hidepid={1,2}` property -->
   <!--
   This enables attaching to containers when the host's `/proc` filesystem was mounted with the `hidepid={1,2}` option which restricts access to `/proc/PID` directories.
   -->
   ホストの `/proc` が、`/proc/PID` ディレクトリに対するアクセスを制限する `hidepid={1,2}` を指定してマウントされている場合でも、コンテナにアタッチできるようになりました。
   
-  #### マウント時のマウントプロパゲーションのサポート <!-- Support mount propagation for mounts -->
+  ## マウント時のマウントプロパゲーションのサポート <!-- Support mount propagation for mounts -->
   <!--
   This adds support for mount propagation (`private`, `shared`, `slave`, `unbindable`, `rprivate`, `rshared`, `rslave`, `runbindable`) to mount entries specified via `lxc.mount.entry` and `lxc.mount.fstab`.
   -->
   `lxc.mount.entry` と `lxc.mount.fstab` で指定されるマウントエントリに、マウントプロパゲーション (`private`, `shared`, `slave`, `unbindable`, `rprivate`, `rshared`, `rslave`, `runbindable`) が指定できるようになりました。
   
-  #### 確実なスレッドセーフ <!-- Hardened thread-safety -->
+  ## 確実なスレッドセーフ <!-- Hardened thread-safety -->
   <!--
   The details of this can be gathered from [this blogpost](https://brauner.github.io/2018/03/04/locking-in-shared-libraries.html).
   -->
   この項目に関する詳細は [Mutexes And fork()ing In Shared Libraries](https://brauner.github.io/2018/03/04/locking-in-shared-libraries.html) というブログポストをご覧ください。
   
-  #### `aufs` ストレージドライバの削除 <!-- Remove `aufs` storage driver -->
+  ## `aufs` ストレージドライバの削除 <!-- Remove `aufs` storage driver -->
   <!--
   The `aufs` storage driver has been deprecated since LXC 2.1 and is now officially removed.
   -->
   LXC 2.1 で廃止予定となっていた `aufs` ストレージドライバが、今回正式に削除されました。
   
-  #### コーディングスタイル、コードのクリーンアップ <!-- Coding style and code cleanups -->
+  ## コーディングスタイル、コードのクリーンアップ <!-- Coding style and code cleanups -->
   <!--
   Code cleanups have been performed widely across the codebase based on our written down [coding style](https://github.com/lxc/lxc/blob/master/CODING_STYLE.md).
   -->
   [コーディングスタイル](https://github.com/lxc/lxc/blob/master/CODING_STYLE.md) に基づいて、コードベース全体に渡って広く、コードのクリーンアップを実行しました。
   
-  ### 新たな設定項目 <!-- New Configuration Keys -->
+  # 新たな設定項目 <!-- New Configuration Keys -->
   
-  #### `lxc.cgroup2.[controller name]`
+  ## `lxc.cgroup2.[controller name]`
   <!--
   Specify the control group value to be set on the unified cgroup shierarchy. The controller name is the literal name of the control group. The permitted names and the syntax of their values is not dictated by LXC, instead it depends on the features of the Linux kernel running at the time  the  container is started, for example, `lxc.cgroup2.memory.high`.
   -->
   単一階層構造の cgroup (cgroup v2) に設定する値を指定します。`controller name` はコントロールグループそのままの名前です (訳注: cgroup 以下に現れるファイル名そのまま)。使える名前や指定する値の書式は LXC が指示することはありません。コンテナ実行時点のカーネルの機能に依存します。例えば `lxc.cgroup2.memory.high` のようになります。
   
-  #### `lxc.hook.version`
+  ## `lxc.hook.version`
   <!--
   To pass the arguments in new style via environment variables set to `1` otherwise set to `0` to pass them as arguments.  This  setting  affects  all  hooks arguments  that were traditionally passed as arguments to the script. Specifically, it affects the container name, section (e.g. 'lxc', 'net') and hook type (e.g.  'clone', 'mount', 'pre-mount') arguments. If new-style hooks are used then the arguments will be available as environment  variables. The container name will be set in `LXC_NAME`. (This is set independently of the value used for this config item.) The section will be set `LXC_HOOK_SECTION` and the hook type will be set in `LXC_HOOK_TYPE`.  It also affects how the paths to file descriptors referring to the container's namespaces are  passed. If  set  to  `1`  then  for  each namespace a separate environment variable `LXC_[NAMESPACE IDENTIFIER]_NS` will be set. If set to `0` then the paths will be passed as arguments to the stop hook.
   -->
   環境変数経由の新しいスタイルで引数を渡すには 1  に設定します。そうでなく、引数として渡すには  0 に設定します。この設定は、古い方法でスクリプトに引数として渡されているすべてのフック引数に影響します。特に、コンテナ名のセクション (例: 'lxc', 'net') とフックタイプ (例: 'clone', 'mount', 'pre-mount') 引数に影響します。新しいスタイルのフックが使われる場合、引数は環境変数として利用できます。コンテナ名は LXC_NAME に設定されます(これはこの設定項目に設定されている値とは関係なく設定されます)。セクションは LXC_HOOK_SECTION に設定されます。そしてフックタイプは LXC_HOOK_TYPE に設定されます。この設定は、コンテナの名前空間を参照するファイルディスクリプタのパスをどのように渡すかにも影響します。1 に設定した場合、名前空間ごとに別の環境変数 LXC_[NAMESPACE IDENTIFIER]_NS に設定されます。0 に設定すると、パスは stop フックの引数として渡されます。
   
-  #### `lxc.execute.cmd`
+  ## `lxc.execute.cmd`
   <!--
   Absolute path from container rootfs to the binary to run by default. This configuration options can be set to to specify the default binary for application container started via the `execute()` API call and accompanies the system container based `lxc.init.cmd` configuration key.
   -->
   デフォルトで実行するバイナリのコンテナの root からの絶対パスを指定します。このオプションは `execute()` API 経由で呼ばれて実行されるアプリケーションコンテナのデフォルトバイナリを指定するために使います。システムコンテナの `lxc.init.cmd` に相当します。
   
-  #### `lxc.init.cwd`
+  ## `lxc.init.cwd`
   <!--
   Absolute path inside the container to use as the working directory.
   -->
   ワーキングディレクトリとして使うコンテナ内の絶対パスです。
   
-  #### `lxc.proc.[proc file name]`
+  ## `lxc.proc.[proc file name]`
   <!--
   Specify the proc file name to be set. The file names available are those listed under the `/proc/PID/` directory.  For example, `lxc.proc.oom_score_adj = 10`.
   -->
   設定したい proc 以下のファイル名。指定できるファイル名は `/proc/PID/` 以下に存在するものです。例えば `lxc.proc.oom_score_adj = 10` のように使います。
   
-  #### `lxc.console.buffer.size`
+  ## `lxc.console.buffer.size`
   <!--
   Setting this option instructs LXC to allocate an in-memory ringbuffer. The container's console output will be written to the ringbuffer.  Note  that ringbuffer  must be at least as big as a standard page size. When passed a value smaller than a single page size LXC will allocate a ringbuffer of a single page size. A page size is usually `4kB`.  The keyword `auto` will cause LXC to allocate a ringbuffer of `128kB`.  When manually specifying a size for  the  ringbuffer the value should be a power of `2` when converted to bytes. Valid size prefixes are `kB`, `MB`, `GB`. (Note that all conversions are based on multiples of `1024`. That means `kb == KiB`, `MB == MiB`, `GB == GiB`.)
   -->
   このオプションを設定すると、LXC はインメモリのリングバッファを割り当てます。コンテナのコンソールはリングバッファに出力されます。リングバッファは少なくとも標準ページサイズの大きさでなければなりません。ページサイズより小さい値を与えた場合は、LXC はページサイズのリングバッファを割り当てます。ページサイズは通常は `4kB` です。`auto` を指定すると、LXC は `128kB` のリングバッファを割り当てます。リングバッファサイズを数値指定する場合、値がバイトに変換されるときに 2 の累乗になります。サイズ接頭辞付きの単位として `kB`、`MB`、`GB` が使えます。(この場合の変換は 1024 の倍数に基づいています。つまり `kB` == `KiB`、`MB` == `MiB`、`GB` == `GiB` という意味です。)
   
-  #### `lxc.console.size`
+  ## `lxc.console.size`
   <!--
   Setting this option instructs LXC to place a limit on the size of the console log file specified in `lxc.console.logfile`. Note that size of  the  log file  must  be  at  least as big as a standard page size. When passed a value smaller than a single page size LXC will set the size of log file to a single page size. A page size is usually `4kB`.  The keyword `auto` will cause LXC to place a limit of `128kB` on the log file.  When manually  specifying a size for the log file the value should be a power of `2` when converted to bytes. Valid size prefixes are `kB`, `MB`, `GB`. (Note that all conversions are based on multiples of `1024`. That means `kb == KiB`, `MB == MiB`, `GB == GiB`.)  If users want to mirror the console ringbuffer on  disk they should set `lxc.console.size` equal to `lxc.console.buffer.size`.
   -->
   LXC は `lxc.console.logfile` で指定したコンソールログのサイズを、このオプションで設定した値に制限します。ログファイルのサイズは少なくとも標準ページサイズでなければなりません。ページサイズ以下の値を設定した場合は、LXC はログファイルのサイズをページサイズに設定します。ページサイズは通常は `4kB` です。`auto` を指定すると、LXC はログファイルのサイズを `128kB` に制限します。ログファイルサイズの値を数値指定する場合、値がバイトに変換されるときに `2` の累乗になります。サイズ接頭辞付きの単位として `kB`、`MB`、`GB` が使えます。(この場合の変換は 1024 の倍数に基づいています。つまり `kB` == `KiB`、`MB` == `MiB`、`GB` == `GiB` という意味です。) ディスク上のコンソールリングバッファとミラーになるようにしたい場合は、`lxc.console.size` と `lxc.console.buffer.size` の値を同じ値に設定します。
   
   
-  #### `lxc.console.rotate`
+  ## `lxc.console.rotate`
   <!--
   Whether  to rotate the console logfile specified in `lxc.console.logfile`.
   -->
   `lxc.console.logfile` で指定したコンソールログファイルをローテートするかどうかを指定します。
   
   
-  #### `lxc.mount.entry` の `relative` オプション <!-- `relative` option for `lxc.mount.entry` -->
+  ## `lxc.mount.entry` の `relative` オプション <!-- `relative` option for `lxc.mount.entry` -->
   <!--
   A mountpoint specified with the `relative` property set will be taken to be relative to the mounted container root. For instance,
   -->
@@ -305,46 +305,46 @@ content: |-
   -->
   は `dev/null` を `${LXC_ROOTFS_MOUNT}/dev/null` と展開し、コンテナ内の `proc/kcore` にマウントします。
   
-  #### `lxc.mount.auto` で指定する `cgroup` マウントの `force` プロパティ <!-- `force` property for `cgroup` mounts specified via `lxc.mount.auto` -->
-  ##### `cgroup:mixed:force:`
+  ## `lxc.mount.auto` で指定する `cgroup` マウントの `force` プロパティ <!-- `force` property for `cgroup` mounts specified via `lxc.mount.auto` -->
+  ### `cgroup:mixed:force:`
   <!--
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup:mixed`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
   -->
   force を指定すると、LXC はあらゆる状況でコンテナのための cgroup マウントを実行します。それ以外は `cgroup:mixed`  と同様です。これは主に cgroup 名前空間が有効な場合に便利です。この場合は完全に安全ですので、LXC は通常コンテナの init バイナリが cgroup をマウントしたままの状態にしておきます。
   
-  ##### `cgroup:ro:force:`
+  ### `cgroup:ro:force:`
   <!--
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup:ro`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
   -->
   force を指定すると、LXC はあらゆる状況でコンテナのための cgroup マウントを実行します。それ以外は `cgroup:ro` と同様です。これは主に cgroup 名前空間が有効な場合に便利です。この場合は完全に安全ですので、LXC は通常コンテナの init バイナリが cgroup をマウントしたままの状態にしておきます。
   
-  ##### `cgroup:rw:force:`
+  ### `cgroup:rw:force:`
   <!--
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup:rw`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
   -->
   force を指定すると、LXC はあらゆる状況でコンテナのための cgroup マウントを実行します。それ以外は `cgroup:rw` と同様です。これは主に cgroup 名前空間が有効な場合に便利です。この場合は完全に安全ですので、LXC は通常コンテナの init バイナリが cgroup をマウントしたままの状態にしておきます。
   
-  ##### `cgroup-full:mixed:force:`
+  ### `cgroup-full:mixed:force:`
   <!--
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup-full:mixed`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
   -->
   force を指定すると、LXC  はあらゆる状況でコンテナのための  cgroup  マウントを実行します。それ以外は `cgroup-full:mixed` と同様です。これは主に cgroup 名前空間が有効な場合に便利です。この場合は完全に安全ですので、LXC は通常コンテナの init バイナリが cgroup をマウントしたままの状態にしておきます。
   
   
-  ##### `cgroup-full:ro:force:`
+  ### `cgroup-full:ro:force:`
   <!--
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup-full:ro`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
   -->
   force を指定すると、LXC はあらゆる状況でコンテナのための cgroup マウントを実行します。それ以外は `cgroup-full:ro` と同様です。これは主に cgroup  名前空間が有効な場合に便利です。この場合は完全に安全ですので、LXC は通常コンテナの init バイナリが cgroup をマウントしたままの状態にしておきます。
   
   
-  ##### `cgroup-full:rw:force:`
+  ### `cgroup-full:rw:force:`
   <!--
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup-full:rw`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
   -->
   force を指定すると、LXC はあらゆる状況でコンテナのための cgroup マウントを実行します。それ以外は `cgroup-full:rw` と同様です。これは主に cgroup  名前空間が有効な場合に便利です。この場合は完全に安全ですので、LXC は通常コンテナの init バイナリが cgroup をマウントしたままの状態にしておきます。
   
-  #### `lxc.namespace.clone`
+  ## `lxc.namespace.clone`
   <!--
   Specify namespaces which the container is supposed to be created with. The namespaces to create are specified as a space separated list. Each namespace must correspond to one of the standard namespace identifiers as seen in the `/proc/PID/ns` directory. When `lxc.namespace.clone` is not explicitly set all namespaces supported by the kernel and the current configuration will be used.
   -->
@@ -355,7 +355,7 @@ content: |-
   -->
   新しいマウント、ネット、IPC 名前空間を作る場合は `lxc.namespace.clone=mount net ipc` と指定します。
   
-  #### `lxc.namespace.keep`
+  ## `lxc.namespace.keep`
   <!--
   Specify  namespaces  which the container is supposed to inherit from the process that created it. The namespaces to keep are specified as a space separated list. Each namespace must correspond to one of the standard namespace identifiers as seen in the `/proc/PID/ns` directory.  The  lxc.namespace.keep is a blacklist option, i.e. it is useful when enforcing that containers must keep a specific set of namespaces.
   -->
@@ -376,7 +376,7 @@ content: |-
   -->
   コンテナが新しいユーザ名前空間をリクエストし、そのコンテナがネットワーク名前空間は継承したい場合は、ユーザ名前空間も同様に継承する必要があることに注意してください。
   
-  #### `lxc.namespace.share.[namespace identifier]`
+  ## `lxc.namespace.share.[namespace identifier]`
   <!--
   Specify a namespace to inherit from another container or process.  The `[namespace identifier]` suffix needs to be replaced with one  of  the  namespaces that appear in the `/proc/PID/ns` directory.
   -->
@@ -412,13 +412,13 @@ content: |-
   -->
   ふたつのプロセスが異なるユーザ名前空間に存在し、そのうちのひとつが他のネットワーク名前空間を継承したい場合、通常はユーザ名前空間も同様に継承する必要があることに注意が必要です。
   
-  #### `lxc.sysctl.[kernel parameters name]`
+  ## `lxc.sysctl.[kernel parameters name]`
   <!--
   Specify the kernel parameters to be set. The parameters available are those listed under `/proc/sys/`. Note that not all sysctls are namespaced. Changing Non-namespaced sysctls will cause the system-wide setting to be modified.  `sysctl(8)`. If used with no value, LXC will clear the parameters  specified up to this point.
   -->
   設定したいカーネルパラメータを指定します。指定できるパラメータは `/proc/sys` 以下に存在するものです。 すべての sysctl パラメータが仮想化（名前空間化）されているわけではないことに注意してください。仮想化されていない sysctl を設定すると、システムワイドで設定が変更されてしまいます。 `sysctl(8)` 値を指定しないでこの設定を指定した場合は、この設定より前に設定されたパラメータをクリアします。
   
-  #### `lxc.hook.start-host`
+  ## `lxc.hook.start-host`
   <!--
   A hook to be run in the host's namespace after the container has been setup, and immediately before starting the container init.
   -->
@@ -452,8 +452,8 @@ content: |-
   NIC `peer1` は期待通りコンテナ内に配置されました。
   これが動作するためには、この時点では `lxc-info` は動作しないので、コンテナの init の pid を環境変数 `LXC_PID` として与える必要があります。
   
-  #### API 拡張 <!-- API extensions -->
-  ##### `console_log()`
+  ## API 拡張 <!-- API extensions -->
+  ### `console_log()`
   <!--
   A new API extension
   -->
@@ -488,13 +488,13 @@ content: |-
           char *data;
       };
   
-  ##### `reboot2()`
+  ### `reboot2()`
   <!--
   This adds `reboot2()` as a new API extension. This function properly wait until a reboot succeeded. It takes a timeout argument. When set to `> 0` `reboot2()` will block until the timeout is reached, if timeout is set to zero `reboot2()` will not block, if set to `-1` `reboot2()` will block indefinitely.
   -->
   新しい API 拡張として `reboot2()` が追加されました。この関数は再起動が成功するまで待ちます。この関数は引数としてタイムアウト値を取ります。タイムアウト値が `> 0` の場合、`reboot2()` はタイムアウトに達するまで再起動を待ちます。もしタイムアウトが `0` に設定された場合、`reboot2()` は再起動を待ちません。もし `-1` に設定された場合、`reboot2()` は無期限に再起動を待ちます。
   
-  ##### CRIU の `migrate()` API 呼び出しに対する `MIGRATE_FEATURE_CHECK` <!-- `MIGRATE_FEATURE_CHECK` for `CRIU` ``migrate()` API call -->
+  ### CRIU の `migrate()` API 呼び出しに対する `MIGRATE_FEATURE_CHECK` <!-- `MIGRATE_FEATURE_CHECK` for `CRIU` ``migrate()` API call -->
   <!--
   For migration optimization features like pre-copy or post-copy migration the support cannot be determined by simply looking at the `CRIU` version.  Features like that depend on the architecture/kernel/criu combination and `CRIU` offers a feature checking interface to query if it is supported.
   -->
@@ -520,13 +520,13 @@ content: |-
   -->
   現時点では、`FEATURE_MEM_TRACK` と `FEATURE_LAZY_PAGES` 機能がサポートされているかどうかを問い合わせるだけです。
   
-  ##### `attach()` API 呼び出しに対する `LXC_ATTACH_TERMINAL` の追加 <!-- add `LXC_ATTACH_TERMINAL` to `attach()` API call -->
+  ### `attach()` API 呼び出しに対する `LXC_ATTACH_TERMINAL` の追加 <!-- add `LXC_ATTACH_TERMINAL` to `attach()` API call -->
   <!--
   Allocation of a new terminal has been moved into the API itself. Callers can  now set `LXC_ATTACH_TERMINAL` to request to be attached to a new terminal allocated from the host's `devpts` mount before attaching to the container.
   -->
   新しい端末の割り当てが API 自身に移されました。呼び出し元は `LXC_ATTACH_TERMINAL` を設定し、コンテナにアタッチする前に、ホストの `devpts` から割り当てられた新しい端末にアタッチするように要求できます。
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.0.0 will be supported until June 2023 and our current LTS release.
   LXC 2.0 will now join LXC 1.0 in only getting critical bugfixes and security updates.
@@ -540,13 +540,13 @@ content: |-
   -->
   LXC チームは 3.0 ブランチへのアップグレードの計画を立てることを強くおすすめします。libpam-cgfs が LXC へ移動しますので、LXC 3.0 へのアップグレードと同時に LXCFS 3.0 へのアップグレードを行うと、機能のコンフリクトを避けることができるでしょう。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - LXC リリース tarball <!--LXC release tarball -->: [lxc-3.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.0.tar.gz) (GPG: [lxc-3.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.0.tar.gz.asc))
    - LXC テンプレート tarball <!-- LXC templates tarball -->: [lxc-templates-3.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.0.tar.gz) (GPG: [lxc-templates-3.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.0.tar.gz.asc))
    - LXC python3 バインディング tarball <!-- LXC python3 bindings tarball -->: [python3-lxc-3.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.1.tar.gz) (GPG: [python3-lxc-3.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.1.tar.gz.asc))
   
   
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXC 3.0.0 release was brought to you by a total of 42 contributors.
   -->

--- a/content/lxc/news.ja/lxc-3.0.1.yaml
+++ b/content/lxc/news.ja/lxc-3.0.1.yaml
@@ -2,7 +2,7 @@ title: LXC 3.0.1 リリースのお知らせ
 date: 2018/06/05 00:00
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-1-has-been-released/1949
 content: |-
-  ### はじめに
+  # はじめに
   <!--
   The LXC team is pleased to announce the release of LXC 3.0.1!
   -->
@@ -13,14 +13,14 @@ content: |-
   -->
   Stable に対するバグフィックスのためのリリースですので、大きな変更はありません。バグフィックスと細かな使い勝手の改良にフォーカスしています。
   
-  #### ハイライト <!-- Highlights -->
+  ## ハイライト <!-- Highlights -->
   
    * liblxc の様々な部分でスレッドセーフとなるように改良されました <!-- Improvement in thread safety of various part of liblxc -->
    * Coverity によって見つかった問題を多数修正しました <!-- Lots of bugfixes for issues identified by Coverity -->
    * seccomp の扱いに関していくつか改良が行われました。特に personality に関係する部分です <!-- Several improvements to Seccomp handling, especially related to personalities -->
    * GCC 8 をサポートしました <!-- Support for GCC 8 -->
   
-  #### バグフィックス <!-- Bugfixes -->(LXC)
+  ## バグフィックス <!-- Bugfixes -->(LXC)
   
    * tools: 初期化されていない変数を修正しました <!-- fix uninitialized variable -->
    * storage: lvm fs の uuid 生成の問題を修正しました<!-- fix lvm fs uuid generation -->
@@ -177,19 +177,19 @@ content: |-
    * templates: download テンプレートを修正しました <!-- fix download template -->
    * `lxc-update-config` を修正しました <!-- Patch lxc-update-config -->
   
-  #### バグ修正 <!-- Bugfixes -->(LXC templates)
+  ## バグ修正 <!-- Bugfixes -->(LXC templates)
   
    * sshd: lxc.autodev を使うようにしました <!-- Use lxc.autodev -->
    * sshd: init スクリプトにコンテナ名を渡すようにしました <!-- Pass the container name to the init script -->
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.0.1 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXC 3.0.1 は 2023 年 6 月までサポートされる最新の LTS リリースです。
   利用可能になった最新のバグ修正リリースに更新することをお勧めします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   
    - LXC リリース tarball <!-- Main release tarball -->: [lxc-3.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.1.tar.gz) (GPG: [lxc-3.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.1.tar.gz.asc))
    - LXC テンプレート tarball <!-- LXC templates tarball -->: [lxc-templates-3.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.1.tar.gz) (GPG: [lxc-templates-3.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.1.tar.gz.asc))

--- a/content/lxc/news.ja/lxc-3.0.2.yaml
+++ b/content/lxc/news.ja/lxc-3.0.2.yaml
@@ -2,7 +2,7 @@ title: LXC 3.0.2 リリースのお知らせ
 date: 2018/08/21 00:00
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-2-has-been-released/2504
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 3.0.2!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   Stable に対するバグフィックスのためのリリースですので、大きな変更はありません。バグフィックスと細かな使い勝手の改良にフォーカスしています。
   
-  #### ハイライト <!-- Highlights -->
+  ## ハイライト <!-- Highlights -->
   
    - ユーザ名前空間内ではデバイスを作成できるがオープンできないという Linux `4.18` での変更に合わせました <!-- Adapt to changes in Linux `4.18` which allows to create but not to open devices nodes in user namespaces -->
    - コンテナの起動時にネットワーク名前空間の ID を割り当てるようにしました <!-- Allocate network namespace id on container startup -->
@@ -25,7 +25,7 @@ content: |-
      これによりコードベースのサイズが大幅に減りました <!-- This significantly reduced the size of the codebase. -->
    - コード全体でコーディングスタイルの修正を行いました <!-- Tree-wide coding style fixes -->
   
-  ##### CVE-2018-6556
+  ### CVE-2018-6556
   
   <!--
   This release fixes [CVE-2018-6556](http://seclists.org/oss-sec/2018/q3/81) via commit [CVE 2018-6556: verify netns fd in lxc-user-nic](https://github.com/lxc/lxc/commit/c1cf54ebf251fdbad1e971679614e81649f1c032): `lxc-user-nic` when asked to delete a network interface will unconditionally open a user provided path. 
@@ -42,7 +42,7 @@ content: |-
   -->
   影響を受ける LXC のリリースは、2.0.9 を含む 2.0 以上のバージョン、3.0.2 より前の、3.0.0 を含む 3.0 以上のバージョンです。
   
-  #### バグ修正 <!-- Bugfixes -->(LXC)
+  ## バグ修正 <!-- Bugfixes -->(LXC)
   
    - Coverity が見つけた一連のバグを修正しました <!-- fixed a range of bugs found by Coverity -->
    - lxc-usernsexec: クリーンアップとバグフィックスを行いました <!-- cleanup and bugfixes -->
@@ -93,7 +93,7 @@ content: |-
    - conf: 必要なときだけ `newuidmap` と `newgidmap` を使うようになりました <!-- only use newuidmap and newgidmap when necessary -->
    - autotools: クロスコンパイル時に TLS をサポートするようになりました <!-- support tls in cross-compile -->
   
-  #### バグ修正 <!-- Bugfixes -->(LXC templates)
+  ## バグ修正 <!-- Bugfixes -->(LXC templates)
   
    - fedora: Fedora 28 をサポートを追加しました <!-- support Fedora 28 -->
    - templates: opensuse: openSUSE Leap 15 のサポートを追加しました <!-- Add support for openSUSE Leap 15 -->
@@ -101,18 +101,18 @@ content: |-
    - templates: lxc-opensuse.in: キャッシュが完全に存在していることを保証するようにしました <!-- Ensure cache is fully populated -->
    - templates: lxc-opensuse.in: openSUSE Leap 15 のキャッシュ URL を修正しました <!-- Fix openSUSE Leap 15 cache url -->
   
-  #### バグ修正 (python3 バインディング)<!-- Bugfixes (python3 binding) -->
+  ## バグ修正 (python3 バインディング)<!-- Bugfixes (python3 binding) -->
   
    - README.md 内の Typo を修正しました <!-- Fix typo in README.md -->
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.0.2 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXC 3.0.2 は 2023 年 6 月までサポートされる最新の LTS リリースです。
   利用可能になった最新のバグ修正リリースに更新することをお勧めします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - LXC リリース tarball <!-- Main release tarball -->: [lxc-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.2.tar.gz) (GPG: [lxc-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.2.tar.gz.asc))
    - LXC テンプレート tarball <!-- LXC templates tarball -->: [lxc-templates-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.2.tar.gz) (GPG: [lxc-templates-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.2.tar.gz.asc))
    - LXC python3 バインディング tarball <!-- LXC python3 bindings tarball -->: [python3-lxc-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.2.tar.gz) (GPG: [python3-lxc-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.2.tar.gz.asc))

--- a/content/lxc/news.ja/lxc-3.0.3.yaml
+++ b/content/lxc/news.ja/lxc-3.0.3.yaml
@@ -2,7 +2,7 @@ title: LXC 3.0.3 リリースのお知らせ
 date: 2018/11/22 00:00
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-3-has-been-released/3358
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 3.0.3!
   -->
@@ -13,14 +13,14 @@ content: |-
   -->
   Stable に対するバグフィックスのためのリリースですので、大きな変更はありません。バグフィックスと細かな使い勝手の改良にフォーカスしています。
   
-  #### ハイライト <!-- Highlights -->
+  ## ハイライト <!-- Highlights -->
   
    - コンパイラが持つよりセキュアなバイナリを生成するための機能を使うためにビルドフラグを見直しました <!-- Improved our default build flags to make use of compiler hardening -->
    - 新しいカーネルで使える netlink の厳格なプロパティチェックのサポートを追加しました <!-- Added support for netlink strict property checking on newer kernels -->
    - netlink の新しいインターフェース・アドレスの netns API のサポートを追加しました <!-- Added support for new netlink interface/address netns API -->
    - 起動時のカーネルキーリングの処理を追加しました <!-- Added handling of the kernel keyring on startup -->
   
-  #### バグ修正 <!-- Bugfixes -->(LXC)
+  ## バグ修正 <!-- Bugfixes -->(LXC)
   
    - CONTRIBUTING: カーネルのコーディングスタイルへのリファレンスを更新しました <!-- Update reference to kernel coding style -->
    - CONTRIBUTING: カーネルの最新のオンラインドキュメントへリンクするようにしました <!-- Link to latest online kernel docs -->
@@ -220,24 +220,24 @@ content: |-
    - cgfsng: 要求仕様から freezer を削除しました <!-- remove freezer requirement -->
    - start: `cgroup_exit()` を二度呼ばないようにしました <!-- don't call cgroup\_exit() twice -->
   
-  #### バグ修正（LXCテンプレート） <!-- Bugfixes (LXC templates) -->
+  ## バグ修正（LXCテンプレート） <!-- Bugfixes (LXC templates) -->
   
    - alpine: `setpcap` を drop するのをオプショナルにしました <!-- Make dropping setpcap optional -->
    - plamo: デフォルトバージョンを 7.x にしました <!-- Update the default version to 7.x -->
    - sabayon: ディレクトリが存在するときに失敗しないようにしました <!-- Don't fail on existing directories -->
   
-  #### バグ修正（python3 バインディング） <!-- Bugfixes (python3 binding) -->
+  ## バグ修正（python3 バインディング） <!-- Bugfixes (python3 binding) -->
   
    - このリリースでは変更はありません。バージョンを上げただけです <!-- No changes in this release, version bump only -->
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.0.3 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXC 3.0.3 は 2023 年 6 月までサポートされる最新の LTS リリースです。
   利用可能になった最新のバグ修正リリースに更新することをお勧めします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - LXC リリース tarball <!-- Main release tarball -->: [lxc-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.3.tar.gz) (GPG: [lxc-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.3.tar.gz.asc))
    - LXC テンプレート tarball <!-- LXC templates tarball -->: [lxc-templates-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.3.tar.gz) (GPG: [lxc-templates-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.3.tar.gz.asc))
    - LXC python3 バインディング <!-- LXC python3 bindings tarball -->: [python3-lxc-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.3.tar.gz) (GPG: [python3-lxc-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.3.tar.gz.asc))

--- a/content/lxc/news.ja/lxc-3.0.4.yaml
+++ b/content/lxc/news.ja/lxc-3.0.4.yaml
@@ -2,7 +2,7 @@ title: LXC 3.0.4 リリースのお知らせ
 date: 2019/06/21 22:06
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-4-has-been-released/5080
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 3.0.4!
   -->
@@ -13,20 +13,20 @@ content: |-
   -->
   Stable のバグフィックスリリースですので、大きな変更はありません。バグ修正と細かい使い勝手の改良にフォーカスしています。
 
-  #### ハイライト <!-- Highlights -->
-  ##### [runC の CVE-2019-5736 に対する修正](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
+  ## ハイライト <!-- Highlights -->
+  ### [runC の CVE-2019-5736 に対する修正](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
   <!--
   This release comes with  a fix for the privileged container breakout discovered earlier this year. As per our policy we don't consider privileged containers root safe and thus LXC as not received a CVE for this. However, we still provide a fix in this release. For more details see [this blog post](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container).
   -->
   このリリースでは、今年初めに発見された特権コンテナの脱獄に対する修正が含まれています。我々のポリシーでは、特権コンテナは安全であるとは考えていません。それゆえ LXC はこの CVE を受けていないと考えています。しかし、このリリースでは修正が含まれています。詳細については [このブログポスト](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container) をご覧ください。
 
-  ##### 呼び出し元 uid が前置（prefix）された veth インターフェース名 <!-- Prefix veth interface names with caller's uid -->
+  ### 呼び出し元 uid が前置（prefix）された veth インターフェース名 <!-- Prefix veth interface names with caller's uid -->
   <!--
   To make it easier for users to inspect veth devices LXC will now prefix the uid of the caller for the host veth device.
   -->
   ユーザーが veth デバイスを簡単に調査できるように、LXC がホストの veth デバイスに呼び出し元の uid をプレフィックスとして付与するようになりました。
 
-  ##### Android デバイスでの LXC 使用の改良 <!-- Improve using LXC on Android devices -->
+  ### Android デバイスでの LXC 使用の改良 <!-- Improve using LXC on Android devices -->
   <!--
   This makes LXC look for standard tools in locations such as `/system/bin` that are specific to Android.
   Additionally, it is now possible to correctly allocate loop devices on Android.
@@ -34,7 +34,7 @@ content: |-
   このリリースで、LXC は `/system/bin` のような Android 特有な場所で標準ツールを探すようになりました。
   さらに、Android 上で正しく loop デバイスを割り当てられるようになりました。
 
-  ##### 現在の master で標準のコンパイラが扱うハードニング・オプションすべてをバックポート <!-- Backport all compiler hardening options which are standard on current master. -->
+  ### 現在の master で標準のコンパイラが扱うハードニング・オプションすべてをバックポート <!-- Backport all compiler hardening options which are standard on current master. -->
   <!--
   This backports:
   -->
@@ -74,67 +74,67 @@ content: |-
       -z relro
       -z now
 
-  ##### スタック割り当て（`alloca()`）をすべて削除 <!-- Remove all stack allocation (`alloca()`) -->
+  ### スタック割り当て（`alloca()`）をすべて削除 <!-- Remove all stack allocation (`alloca()`) -->
   <!--
   As is already the case on master, all stack allocations via `alloca()` have been wiped from the codebase to increase security.
   -->
   master で行われたのと同様に、よりセキュアにするために `alloca()` を使ったスタック割り当てをすべてコードベースから削除しました。
 
-  ##### [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) のサポート <!-- Added support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/)  -->
+  ### [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) のサポート <!-- Added support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/)  -->
   <!--
   This adds support for the [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) code quality checker.
   -->
   このリリースで [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) コード品質チェッカーのサポートを追加しました。
 
-  ##### [coccinelle](https://github.com/coccinelle/coccinelle) コード解析（変形）ツールのサポート <!-- Add support for [coccinelle](https://github.com/coccinelle/coccinelle) code transformation tool -->
+  ### [coccinelle](https://github.com/coccinelle/coccinelle) コード解析（変形）ツールのサポート <!-- Add support for [coccinelle](https://github.com/coccinelle/coccinelle) code transformation tool -->
   <!--
   This allows us to automatically detect, remove, or add code to the LXC codebase to improve security and reliability.
   -->
   自動的にコードを LXC のコードベースに検出、削除、追加し、セキュリティと信頼性を改良できます。
 
-  ##### コンパイラベースのリソースクリーンアップ <!-- Compiler based resource cleanup -->
+  ### コンパイラベースのリソースクリーンアップ <!-- Compiler based resource cleanup -->
   <!--
   The codebase will be slowly switched over to make user of cleanup attributes supported by compilers such as `gcc` and `clang`.
   -->
   `gcc` や `clang` と言ったコンパイラがサポートするクリーンアップ属性を使用するために、コードベースはゆっくりと切り替わります。
 
-  ##### コードベースから `fgets()` を削除 <!-- Remove `fgets()` from the codebase -->
+  ### コードベースから `fgets()` を削除 <!-- Remove `fgets()` from the codebase -->
   <!--
   To improve security all uses of `fgets()` have been removed from the codebase. Use of this function in new code is strongly discouraged.
   -->
   セキュリティの改善のため、`fgets()` をコードベースからすべて削除しました。今後、この関数を新たにコードで使用することは推奨しません。
 
-  ##### `cgroup2` の扱いの改良 <!-- Improve `cgroup2` handling -->
+  ### `cgroup2` の扱いの改良 <!-- Improve `cgroup2` handling -->
   <!--
   With this release `cgroup2` layouts will be better supported.
   -->
   このリリースで、`cgroup2` レイアウトのサポートが向上しました。
 
-  ##### `lxc.mount.fstab` の直後に `lxc.mount.entry` を設定する <!-- Setup `lxc.mount.entry` right after `lxc.mount.fstab` -->
+  ### `lxc.mount.fstab` の直後に `lxc.mount.entry` を設定する <!-- Setup `lxc.mount.entry` right after `lxc.mount.fstab` -->
   <!--
   This allows us to unify the mounting logic in LXC.
   -->
   これにより、LXC の実装ロジックを統一できます。
 
-  ##### 名前空間の共有オプションの拡張 <!-- Expand namespace sharing options -->
+  ### 名前空間の共有オプションの拡張 <!-- Expand namespace sharing options -->
   <!--
   When inheriting a namespace a pathname to a namespace file descriptor can now be specified.
   -->
   名前空間（namespace）を継承するとき、名前空間ファイルディスクリプタのパス名を指定できるようになりました。
 
-  ##### close-on-exec の使用の拡張 <!-- Expand close-on-exec usage -->
+  ### close-on-exec の使用の拡張 <!-- Expand close-on-exec usage -->
   <!--
   All file descriptors that can be made close-on-exec are now close-on-exec.
   -->
   close-on-exec にできるファイルディスクリプタは、すべて close-on-exec になりました。
 
-  ##### `pidfd` API のサポート <!-- Support `pidfd` api -->
+  ### `pidfd` API のサポート <!-- Support `pidfd` api -->
   <!--
   Newer kernel versions allow interaction with processes through process file descriptors (`pidfd`s). This eliminates various race conditions when e.g. sending signals or retrieving process information. This LXC version make use of the `pidfd_send_signal()` syscall and the `CLONE_PIDFD` flag with the `clone()` syscall.
   -->
   新しいカーネルでは、プロセスファイルディスクリプタ（`pidfd`）を通じてプロセスと対話できます。これにより、例えばシグナル送信やプロセス情報の取得といった際の、様々な競合状態が解消されます。このバージョンの LXC は `pidfd_send_signal()` システムコールと、`clone()` システムコールで `CLONE_PIDFD` フラグを使うようになります。
 
-  #### バグ修正（LXC）<!-- Bugfixes (LXC) -->
+  ## バグ修正（LXC）<!-- Bugfixes (LXC) -->
 
   - 消去のためにパスを早期に開放することによる cgroup 削除の問題を修正しました <!-- Fix cgroup deletion by not prematurely freeing the path to delete -->
   - デフォルトの ID マッピングにフォールバックする際の `lxc-usernsexec` の問題を修正しました <!-- Fix `lxc-usernsexec` when falling back to the default id mapping -->
@@ -440,24 +440,24 @@ content: |-
    - cgfsng: write cpuset.mems of correct ancestor
 
 
-  #### バグ修正 <!-- Bugfixes -->(LXC templates)
+  ## バグ修正 <!-- Bugfixes -->(LXC templates)
 
    - slackware: wget のための新たな依存パッケージを `lxc-slackware` テンプレートに追加しました <!-- Add new dependency for wget for lxc-slackware template -->
    - plamo: 最新バージョンの 7.x コンテナ上で、32bit 版バージョン 6.x コンテナをビルドする際の問題を修正しました <!-- Workaround for building plamo 32bit 6.x container on current 7.x -->
    - plamo: パッケージダウンロードのスキーマとして `https` を追加し、デフォルトを `https` にしました <!-- Support https as download scheme and default to https -->
 
-  #### バグ修正 <!-- Bugfixes -->(python3 binding)
+  ## バグ修正 <!-- Bugfixes -->(python3 binding)
 
    - 変更はありません。バージョン番号が増加したのみ <!-- No changes in this release, version bump only -->
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.0.4 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXC 3.0.4 は 2023 年 6 月までサポートされる最新の LTS リリースです。
   利用可能になった最新のバグ修正リリースに更新することをお勧めします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - LXC リリース tarball <!-- Main release tarball -->: [lxc-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.4.tar.gz) (GPG: [lxc-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.4.tar.gz.asc))
    - LXC テンプレート tarball <!-- LXC templates tarball -->: [lxc-templates-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.4.tar.gz) (GPG: [lxc-templates-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.4.tar.gz.asc))
    - LXC python3 バインディング tarball <!-- LXC python3 bindings tarball -->: [python3-lxc-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.4.tar.gz) (GPG: [python3-lxc-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.4.tar.gz.asc))

--- a/content/lxc/news.ja/lxc-3.1.yaml
+++ b/content/lxc/news.ja/lxc-3.1.yaml
@@ -2,7 +2,7 @@ title: LXC 3.1 リリースのお知らせ
 date: 2018/12/13 00:00
 origin: https://discuss.linuxcontainers.org/t/lxc-3-1-has-been-released/3527
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 3.1.0!
   -->
@@ -13,14 +13,14 @@ content: |-
   -->
   これは、メジャーな LTS や LTS のバグフィックスのためのリリースではなく、それに向けての中間的な新機能を盛り込んだリリースです。将来的にはこの作業をさらに進める予定です。しかし、このリリースのサポートは限定的なものになります。これは、開発の大部分はプロダクション環境向けの LTS リリースにフォーカスしているためです。
   
-  ### 新機能 <!-- New features -->
-  #### AppArmor でのいくつかの再マウントオプションの有効化 <!-- enable various remount options with AppArmor -->
+  # 新機能 <!-- New features -->
+  ## AppArmor でのいくつかの再マウントオプションの有効化 <!-- enable various remount options with AppArmor -->
   <!--
   Read-write bind mounts need to be restricted for some paths in order to avoid MAC restriction bypasses, but read-only bind mounts shouldn't have that problem. Additionally, combinations of `nosuid`, `nodev` and `noexec` flags shouldn't be a problem either and are required with newer systemd versions, so let's allow those as long as they're combined with `ro,remount,bind`.
   -->
   読み書き可能なバインドマウントは MAC 制限をすり抜けるのを防ぐために、一部のパスで制限する必要があります。しかし、読み込み専用のバインドマウントではこのような問題はありません。さらに `nosuid`、`nodev`、`noexec` フラグの組み合わせでも問題となることはなく、この組み合わせは新しいバージョンの systemd で必要になります。このような理由から、これらのオプションと `ro,remount,bind` との組み合わせではマウントを許可します。
   
-  #### `NETLINK_DUMP_STRICT_CHK` のサポート<!-- support `NETLINK_DUMP_STRICT_CHK` -->
+  ## `NETLINK_DUMP_STRICT_CHK` のサポート<!-- support `NETLINK_DUMP_STRICT_CHK` -->
   <!--
   Make use of the new socket option, `NETLINK_DUMP_STRICT_CHK`, that userspace can use via `setsockopt()` to request strict checking of headers and attributes on dump requests.
   -->
@@ -31,55 +31,55 @@ content: |-
   -->
   ダンプリクエストに追加するヘッダーや属性のデータをもとにしたカーネル側のフィルタリングのようなダンプ機能を利用するには、ユーザースペースは `NETLINK_DUMP_STRICT_CHK` と 0 でない値で `setsockopt()` を呼ばなければなりません。これは LXC がネットワーク名前空間から情報を効率的に取得するのに使う `IFA_TARGET_NETNSID` の利用に必要です。
   
-  #### コンテナ起動時の新たなキーリング割り当て <!-- allocate new keyring on startup -->
+  ## コンテナ起動時の新たなキーリング割り当て <!-- allocate new keyring on startup -->
   <!--
   To isolate and protect the hosts keyring each LXC container will try to allocate a new keyring for itself on startup.
   -->
   ホストのキーリングを隔離して保護するために、LXC コンテナはそれぞれ、起動時に新しいキーリングを割り当てようとします。
   
-  #### 完全な `cgroup2` のサポート <!-- full `cgroup2` support -->
+  ## 完全な `cgroup2` のサポート <!-- full `cgroup2` support -->
   <!--
   LXC has supported `cgroup2` for a while now without adhering to its strict delegation model. Now, LXC is ready to fully support it.
   -->
   LXC はしばらくの間、厳密な権限委譲モデルを守らずに `cgroup2` をサポートしてきました。現在は `cgroup2` をフルにサポートしました。
   
-  #### コンテナからネットワークデバイスとアドレスを取得する効率的な方法の実装 <!-- implement efficient way to retrieve network devices and addresses from containers -->
+  ## コンテナからネットワークデバイスとアドレスを取得する効率的な方法の実装 <!-- implement efficient way to retrieve network devices and addresses from containers -->
   <!--
   Based on kernel work done by the LXD team it is now possible to query a network namespace without having to perform costly `fork()` and `setns()` syscalls. Instead, the network namespace is identified by a network namespace identifier. As such a new network namespace aware version and very improved and safe version of `getifaddrs()` named `netns_getifaddrs()` is introduced that LXC uses. It is a strict superset of `getifaddrs()`.
   -->
   LXD チームが行ったカーネルでの作業によって、コストのかかる `fork()` や `setns()` システムコールを実行する必要なく、ネットワーク名前空間を問い合わせることができるようになりました。代わりに、ネットワーク名前空間はネットワーク名前空間識別子を使って識別します。LXC は、このような新しいネットワーク名前空間が使えるバージョンと、`getifaddrs()` を非常に改良し安全になったバージョンである `netns_getifaddrs()` を使うようになりました。これは `getifaddrs()` の厳格なスーパーセットです。
   
-  #### API に `lxc_has_api_extension()` を追加 <!-- introduce `lxc_has_api_extension()` into the API -->
+  ## API に `lxc_has_api_extension()` を追加 <!-- introduce `lxc_has_api_extension()` into the API -->
   <!--
   Going forward each new API addition will be given a unique name that can be passed to `lxc_has_api_extension()`. This is modeled after LXD's API extension checks. This allows API users to query the given LXC instance whether a given API extension is supported.
   -->
   今後実装される新しい API が追加されるたびに、`lxc_has_api_extension()` に与えるユニークな名前が与えられます。これは LXD の API 拡張のチェックをモデルにしています。これにより、API ユーザーが特定の API 拡張がサポートされているかどうかを LXC インスタンスに問い合わせることができるようになります。
   
-  #### `lxc.cgroup.relative` 設定キーの追加 <!-- add `lxc.cgroup.relative` configuration key -->
+  ## `lxc.cgroup.relative` 設定キーの追加 <!-- add `lxc.cgroup.relative` configuration key -->
   <!--
   This adds the new `lxc.cgroup.relative` config key. The key can be used to instruct LXC to never escape to the root cgroup. This makes it easy for users to adhere to restrictions enforced by `cgroup2` and `systemd`. Specifically, this makes it possible to run LXC containers as systemd services.
   -->
   新たに設定項目として `lxc.cgroup.relative` を追加しました。この設定で LXC に root cgroup へエスケープしないように指示できます。これにより、ユーザーは `cgroup2` と `systemd` が強制する制限を遵守するのが容易になります。具体的には、LXC コンテナを systemd サービスとして実行できます。
 
-  #### （コンテナ）起動時の新しいネットワーク名前空間識別子の割り当て <!-- allocate new network namespace identifier on startup -->
+  ## （コンテナ）起動時の新しいネットワーク名前空間識別子の割り当て <!-- allocate new network namespace identifier on startup -->
   <!--
   Each container will now have a unique network namespace identifier assigned on startup. This can be used by LXC to siginficantly speed up operations performed on network namespaces (e.g. network device configuration and retrieval).
   -->
   コンテナごとに、起動時に割り当てるユニークなネットワーク名前空間識別子を持つようになりました。LXC はこれを使い、ネットワーク名前空間上で実行する操作を大幅にスピードアップします。（ネットワークデバイスの設定や取得）。
   
-  #### `lxc.rootfs.managed` 設定キーの追加 <!-- add `lxc.rootfs.managed` configuration key -->
+  ## `lxc.rootfs.managed` 設定キーの追加 <!-- add `lxc.rootfs.managed` configuration key -->
   <!--
   This introduces a new config key which can be used to indicate whether this LXC instance is managing the container storage. If LXC is not managing the storage then LXC will not modify the container storage. For example, an API call to `c->destroy(c)` will then run any destroy hooks but will not destroy the actual rootfs (Unless, of course, the hook does so behind LXC's back.).
   -->
   LXC インスタンスがコンテナストレージを管理しているかどうかを示すために使える新しい設定キーを追加しました。LXC がストレージを管理していない場合、LXC はコンテナストレージ変更しません。例えば、API `c->destroy(c)` を呼び出すと、destroy フックが実行されますが、実際に rootfs は削除しません（もちろん、フックが LXC の背後でそのような処理を実行しない限り）。
   
-  #### すべての `VLA` の削除 <!-- removal of all `VLA`s -->
+  ## すべての `VLA` の削除 <!-- removal of all `VLA`s -->
   <!--
   LXC is now compiled with `-Wvla` by default.
   -->
   LXC はデフォルトで `-Wvla` を付けてコンパイルされるようになりました。
   
-  #### AppArmor プロファイルの生成 <!-- AppArmor profile generation -->
+  ## AppArmor プロファイルの生成 <!-- AppArmor profile generation -->
   <!--
   This copies lxd's AppArmor profile generation. This tries to detect features such as cgroup namespaces, AppArmor namespaces and stacking support, and has profile parts conditionally for unprivileged containers.
   -->
@@ -103,7 +103,7 @@ content: |-
   -->
   `apparmor_parser` のキャッシュを使うために、`./configure` オプションに `--with-apparmor-cache-dir` を追加します。
 
-  #### マウントを挿入する API の追加 <!-- add mount injection api -->
+  ## マウントを挿入する API の追加 <!-- add mount injection api -->
   <!--
   This work has been done as part of the bachelor thesis of [LizaTretyakova](https://github.com/LizaTretyakova). The team is very happy and thankful for this outstanding work!
   -->
@@ -132,19 +132,19 @@ content: |-
       int (*umount)(struct lxc_container *c, const char *target, unsigned long mountflags,
                             struct lxc_mount *mnt);
   
-  #### `lxc.monitor.signal.pdeath` の追加 <!-- add `lxc.monitor.signal.pdeath` configuration key -->
+  ## `lxc.monitor.signal.pdeath` の追加 <!-- add `lxc.monitor.signal.pdeath` configuration key -->
   <!--
   Set the signal to be sent to the container's init when the lxc monitor exits. By default it is set to `SIGKILL` which will cause all container processes to be killed when the lxc monitor process dies. To ensure that containers stay alive even if lxc monitor dies set this to `0`.
   -->
   lxc モニタープロセスが exit した際に、コンテナの init に送るシグナルを設定します。デフォルトでは `SIGKILL` が設定されています。つまり、lxc モニタープロセスが死んだ場合は、コンテナのプロセスすべてが kill されることになります。lxc モニタープロセスが死んでもコンテナを起動したままにしておきたい場合はこれを `0` にセットします。
   
-  #### `liblxc` の共有と静的ライブラリのビルド <!-- build a shared and static `liblxc` library -->
+  ## `liblxc` の共有と静的ライブラリのビルド <!-- build a shared and static `liblxc` library -->
   <!--
   LXC will now by default build both a shared and a static library.
   -->
   デフォルトで、LXC では共有と静的の両方のライブラリがビルドされるようになりました。
   
-  #### Linux カーネル 4.18 で行われた `mknod()` の変更への適応 <!-- adapt to `mknod()` changes in Linux Kernel 4.18 -->
+  ## Linux カーネル 4.18 で行われた `mknod()` の変更への適応 <!-- adapt to `mknod()` changes in Linux Kernel 4.18 -->
   <!--
   Starting with commit
   -->
@@ -185,19 +185,19 @@ content: |-
   -->
   これにより `EPERM` が発生します。なぜなら、デバイスノードは非 init のユーザー名前空間が所有するファイルシステム上に存在し、`SB_I_NODEV` により、デバイスノードへのアクセスが許可されないからです。LXC は、このケースを正しく扱うようになりました。
   
-  #### アプリケーションコンテナの実行に `execveat()` を使用 <!-- use `execveat()` to execute application containers -->
+  ## アプリケーションコンテナの実行に `execveat()` を使用 <!-- use `execveat()` to execute application containers -->
   <!--
   Application containers rely on a minimal init system to run their workloads. Instead of executing it by opening a file that is bind-mounted into the container simply pass a file descriptor to `execveat()`. This makes application container startup safer and simpler.
   -->
   アプリケーションコンテナは、そのワークロードを実行するために、最小限の機能を持つ init システムに依存します。コンテナ内にバインドマウントしたファイルを開くことでアプリケーションコンテナを実行する代わりに、シンプルに `execveat()` にファイルディスクリプタを渡します。これにより、アプリケーションコンテナがより安全にシンプルに起動します。
   
-  #### ロギング時のスレッドごとのコンテナ名出力が可能に <!-- enable per-thread container name prefix when logging -->
+  ## ロギング時のスレッドごとのコンテナ名出力が可能に <!-- enable per-thread container name prefix when logging -->
   <!--
   Now each thread that runs a different container but shares a single log file can be identified by printing the name of the container into the log.
   -->
   異なるコンテナを実行しているが、単一のログファイルを共有しているスレッドはそれぞれ、コンテナ名をログに出力することで識別できるようになりました。
   
-  #### cgroup の扱いのリファクタリング <!-- refactor cgroup handling -->
+  ## cgroup の扱いのリファクタリング <!-- refactor cgroup handling -->
   <!--
   This replaces the constructor implementation of cgroup handling with a simpler, thread-safe on-demand model of cgroup driver initialization.
   Making the cgroup initialization code run in a constructor means that each time the shared library gets mapped the cgroup parsing code gets run. That was unnecessary overhead. The cleaner implementation is to allocate a cgroup driver on demand whenever it is needed.
@@ -205,7 +205,7 @@ content: |-
   cgroup のコンストラクタ実装を、よりシンプルで、スレッドセーフなオンデマンドモデルの cgroup ドライバーの初期化モデルに置き換えました。
   cgroup 初期化コードをコンストラクタ内で実行することは、共有ライブラリがマップされるたびに cgroup をパースするコードが走ることを意味します。これは不要なオーバーヘッドでした。よりクリーンな実装は、必要になったときにオンデマンドで cgroup ドライバーを割り当てることです。
   
-  #### フック実行時に ambient ケーパビリティを上げる <!-- raise ambient capabilities when running hooks -->
+  ## フック実行時に ambient ケーパビリティを上げる <!-- raise ambient capabilities when running hooks -->
   <!--
   In very restricted containers (e.g. unprivileged containers that only run with a single mapping for a non-root user) it was not possible to perform operations that require privilege during startup.
   By raising ambient capabilities when a hook is run it is possible to preserve privileges across `exec`.
@@ -213,19 +213,19 @@ content: |-
   非常に制限されたコンテナ（例えば、単一の root 以外のユーザーにのみマッピングされて実行している非特権コンテナ）では、起動時に特権が必要な操作を実行できませんでした。
   フックの実行時に ambient ケーパビリティを上げることで、`exec` を超えて特権を維持できます。
   
-  #### 非特権コンテナ内で `/sys` を `rw` でマウント可能に <!-- allow to mount `/sys` `rw` in unprivileged containers -->
+  ## 非特権コンテナ内で `/sys` を `rw` でマウント可能に <!-- allow to mount `/sys` `rw` in unprivileged containers -->
   <!--
   With new kernel work done by the LXD team it is now possible to send uevents inside user namespaces. This means it is time to let `udev` run inside containers. A pre-condition for this is that `/sys` is mounted `rw`. If it is not `udev` will refuse to start.
   -->
   LXD チームによる新しいカーネルへの取り組みにより、ユーザー名前空間内へ uevent を送ることができるようになりました。これは、コンテナ内で `udev` が実行できるようになったことを意味します。この前提条件は、`/sys` が `rw` でマウントされていることです。そうでなければ、`udev` は起動を拒否します。
   
-  #### `strlcpy()` と `strlcat()` を追加、`strncpy()` と `strncat()` を廃止 <!-- add `strlcpy()` and `strlcat()` and deprecate `strncpy()` and `strncat()` -->
+  ## `strlcpy()` と `strlcat()` を追加、`strncpy()` と `strncat()` を廃止 <!-- add `strlcpy()` and `strlcat()` and deprecate `strncpy()` and `strncat()` -->
   <!--
   This makes string handling safer as `strlcat()` and `strlcpy()` always return a valid string and allow to properly check for truncation.
   -->
   `strlcat()` と `strlcpy()` は常に有効な文字列を返し、適切に切り詰めのチェックができますので、文字列の扱いがより安全になりました。
   
-  #### コンパイラベースのハードニング <!-- compiler based hardening -->
+  ## コンパイラベースのハードニング <!-- compiler based hardening -->
   <!--
   By default `LXC` will turn on  variety of compiler hardening options  such as:
   -->
@@ -239,13 +239,13 @@ content: |-
       --mcet -fcf-protection
       -Werror=implicit-function-declaration
   
-  #### スレッドセーフに関する改良 <!-- thread-safety improvements -->
+  ## スレッドセーフに関する改良 <!-- thread-safety improvements -->
   <!--
   The codebase has been further hardended to be usable in multi-threaded environments
   -->
   コードベースはマルチスレッド環境で使えるように、より強化されました。
   
-  #### seccomp: アーキテクチャースタッキングのサポート <!-- support architecture stacking -->
+  ## seccomp: アーキテクチャースタッキングのサポート <!-- support architecture stacking -->
   <!--
   This allows to support e.g. the following use-case and more:
   -->
@@ -256,7 +256,7 @@ content: |-
    - 64bit コンテナを実行する 32bit コンテナを実行する 64bit カーネルと 64bit ユーザースペース <!-- 64bit kernel and 64bit userspace running 32bit containers running 64bit containers -->
    - ...
   
-  #### コンテナ内に `uid 0` がないアプリケーションコンテナのサポート <!-- support application containers without `uid 0` in the container -->
+  ## コンテナ内に `uid 0` がないアプリケーションコンテナのサポート <!-- support application containers without `uid 0` in the container -->
   <!--
   This allows to start containers that do not have a mapping for `uid 0` inside of the container. 
   Here's an example config:
@@ -280,24 +280,24 @@ content: |-
       lxc.init.uid = 1001
       lxc.init.gid = 1001
   
-  #### `gid` マウントオプションがないカーネル上での `devpts` マウントのサポート <!-- support `devpts` mounts on kernels without `gid` mount option -->
+  ## `gid` マウントオプションがないカーネル上での `devpts` マウントのサポート <!-- support `devpts` mounts on kernels without `gid` mount option -->
   <!--
   Older kernels do not support the `gid` mount option to grant access to a specific group. LXC will now handle this case automatically and only add `gid = 5` if the `gid` mount option is supported by the kernel.
   -->
   古いカーネルは特定のグループへのアクセスを許可するための `gid` マウントオプションをサポートしません。LXC はこのケースを自動的に扱い、カーネルで `gid` マウントオプションがサポートされている場合のみ、`gid = 5` を追加します。
   
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   LXC 3.1.0 includes all the same bugfixes as LXC 3.0.1, 3.0.2 and 3.0.3.
   -->
   LXC 3.1.0 は LXC 3.0.1、3.0.2、3.0.3 と同じバグ修正がすべて含まれています。
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.1 isn't a LTS release and so will only be supported until such time as LXC 3.2 is released. We recommend users that need a stronger support commitment to stay on one of our LTS releases.
   -->
   LXC 3.1 は LTS リリースではありません。したがって、LXC 3.2 がリリースされるまでのみサポートされます。強力なサポートのコミットが必要なユーザーは LTS リリースを使い続けることをおすすめします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - LXC リリース tarball <!-- LXC release tarball -->: [lxc-3.1.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.1.0.tar.gz) (GPG: [lxc-3.1.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.1.0.tar.gz.asc))
   

--- a/content/lxc/news.ja/lxc-3.2.1.yaml
+++ b/content/lxc/news.ja/lxc-3.2.1.yaml
@@ -2,7 +2,7 @@ title: LXC 3.2.1 リリースのお知らせ
 date: 2019/07/24 02:07
 origin: https://discuss.linuxcontainers.org/t/lxc-3-2-1-has-been-released/5322
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 3.2.1!
   -->
@@ -13,9 +13,9 @@ content: |-
   -->
   3.2.0 のリリースプロセスに問題があったため、3.2.1 をすぐにリリースしなければなりませんでした。このリリースで `configure.ac` ファイルにリリースが stable であることをす示すよう修正しました。
 
-  ### 新機能 <!-- New features -->
+  # 新機能 <!-- New features -->
 
-  #### seccomp: システムコールのユーザースペースへのフォワーディングのサポート <!-- Support syscall forwarding to userspace -->
+  ## seccomp: システムコールのユーザースペースへのフォワーディングのサポート <!-- Support syscall forwarding to userspace -->
   <!--
   Newer kernels allow seccomp to forward intercepted syscalls to a dedicated file descriptor. These messages can be read, the syscall arguments inspected, and if found secure, a sufficiently privileged userspace process can perform the actions normally done by the kernel for the container.
   -->
@@ -36,13 +36,13 @@ content: |-
   -->
   この機能を使って、LXD は例えば、`mknod()` や `mknodat()` システムコールを使ったデバイスノードの作成ができます。このようなことは、セキュアなデバイスが明確に定義されているコンテナでは通常は禁止されています。
 
-  #### 設定 `lxc.seccomp.allow_nesting` の追加 <!-- Add `lxc.seccomp.allow_nesting` configuration key -->
+  ## 設定 `lxc.seccomp.allow_nesting` の追加 <!-- Add `lxc.seccomp.allow_nesting` configuration key -->
   <!--
   This release adds the lxc.seccomp.allow_nesting api extension. If `lxc.seccomp.allow_nesting` is set to 1 then seccomp profiles will be stacked. This way nested containers can load their own seccomp policy on top of the policy that the outer container might have applied.
   -->
   このリリースで `lxc.seccomp.allow_nesting` API 拡張を追加しました。`lxc.seccomp.allow_nesting` が 1 に設定されている場合、seccomp プロファイルはスタックされます。このように、ネストされたコンテナが、祖先のコンテナが適用した可能性のあるポリシーに加えて、自身の seccomp ポリシーをロードできます。
 
-  #### ネットワーク: IPVLAN サポート <!-- Networking: Add IPVLAN support -->
+  ## ネットワーク: IPVLAN サポート <!-- Networking: Add IPVLAN support -->
   <!--
   LXC has gained support for IPVLAN. Here is an example how to setup the network:
   -->
@@ -54,7 +54,7 @@ content: |-
       lxc.net[i].link=eth0
       lxc.net[i].flags=up
 
-  #### ネットワーク: レイヤー 2（ARP/NDP）プロキシモードの追加 <!-- Networking: Add layer 2 (ARP/NDP) proxy mode -->
+  ## ネットワーク: レイヤー 2（ARP/NDP）プロキシモードの追加 <!-- Networking: Add layer 2 (ARP/NDP) proxy mode -->
   <!--
   LXC now supports layer 2 ARD/NDP proxy mode. This can be enabled by using:
   -->
@@ -62,13 +62,13 @@ content: |-
 
       lxc.net.[i].l2proxy = [0,1] (defaults to 0)
 
-  #### ネットワーク: ゲートウェイのデバイスルートモードの追加 <!-- Networking: Add gateway device route mode -->
+  ## ネットワーク: ゲートウェイのデバイスルートモードの追加 <!-- Networking: Add gateway device route mode -->
   <!--
   LXC now supports specifying `lxc.net.[i].ipv4.gateway` and/or `lxc.net.[i].ipv6.gateway` with a value of `dev`. This will cause LXC to set a device route as default gateway.
   -->
   LXC で `lxc.net.[i].ipv4.gateway` もしくは `lxc.net.[i].ipv6.gateway`、またはその両方に `dev` という値を設定できるようになりました。これにより、デフォルトゲートウェイとしてデバイスのルートが設定されます。
 
-  #### ネットワーク: スタティックルートのサポート <!-- Networking: Add support for static routes -->
+  ## ネットワーク: スタティックルートのサポート <!-- Networking: Add support for static routes -->
   <!--
   This release introudces two new configuration keys
   -->
@@ -82,7 +82,7 @@ content: |-
   -->
   これにより、ユーザーは veth インターフェースにスタティックルートを設定できます。
 
-  #### Networking: Add router veth mode
+  ## Networking: Add router veth mode
   <!--
   LXC has gained a new router mode for veth networking. This "router" mode will configure the host machine as a router for the container by adding static routes for the container's IPs on the host pointing to the container's host-side veth interface. It will also add static IP proxy entries of either the host's link interface IP or a statically set IP on the host-side veth interface to provide the container a gateway to the host.
   -->
@@ -118,13 +118,13 @@ content: |-
   * ローカルのルーティングテーブルにあるコンテナの IP アドレスを広域のネットワークに配布するために、ホスト上で BGP（や他のルーティングプロトコル）が実行されている設定に対して、レイヤー 3 のみのモードをサポートする <!-- Supports layer 3 only mode for setups where BGP (or other routing protocols) are running on the host to distribute container's IPs in the local routing table to the wider network. -->
   * コンテナは、既存の `l2proxy` と `link` 設定を使って、レイヤー 2 のローカルな LAN 上でアクセス可能な IP アドレスをオプションで持てる <!-- Containers can optionally have IPs accessible on local LAN at layer 2 using the existing  `l2proxy` and  `link`  settings. -->
 
-  #### pidfd: 新しい pidfd API の初期サポート <!-- Add initial support for the new pidfd api -->
+  ## pidfd: 新しい pidfd API の初期サポート <!-- Add initial support for the new pidfd api -->
   <!--
   Newer kernel versions allow interaction with processes through process file descriptors (pidfds). This eliminates various race conditions when e.g. sending signals or retrieving process information. This LXC version make use of the pidfd_send_signal() syscall and the CLONE_PIDFD flag with the clone() syscall.
   -->
   新しいバージョンのカーネルでは、プロセスファイルディスクリプタ（pidfds）を通してプロセスと対話できます。これにより、例えばシグナルの送信やプロセス情報の取得のような場合での様々な競合状態が解消されます。このバージョンの LXC では、`pidfd_send_signal()` システムコールと、`clone()` システムコールに対して `CLONE_PIDFD` フラグを使います。
 
-  #### ハードニング: さらにコンパイラベースのハードニングを追加 <!-- Hardening: Add more compiler based hardening -->
+  ## ハードニング: さらにコンパイラベースのハードニングを追加 <!-- Hardening: Add more compiler based hardening -->
   <!--
   Over the last few releases we enabled options compilers provide to harden C codebases. This release enables:
   -->
@@ -153,79 +153,79 @@ content: |-
       -pipe
       -fexceptions
 
-  #### ハードニング: すべてのスタック割当てを削除 <!-- Hardening: Remove all stack allocations -->
+  ## ハードニング: すべてのスタック割当てを削除 <!-- Hardening: Remove all stack allocations -->
   <!--
   Stack-based memory allocations (e.g. through `alloca()`) can cause quite severe memory bugs. LXC has therefore removed all stack-based memory allocations and will not allow new code to add any.
   -->
   スタックベースのメモリ割り当て（例えば `alloca()` を使った）は、非常に深刻なメモリのバグを引き起こす可能性があります。そのため、LXC ではすべてのスタックベースのメモリ割り当てを削除し、新しいコードでも追加は許可しません。
 
-  #### ハードニング: [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) のサポート <!-- Hardening: Add support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) -->
+  ## ハードニング: [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) のサポート <!-- Hardening: Add support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) -->
   <!--
   LXC has gained support for the LGTM code analysis tool. We're happy that LXC's code is currently ranked as A+.
   -->
   LGTM コード解析ツールのサポートを追加しました。LXC のコードは現在 A+ にランク付けされていてハッピーです。
 
-  #### ハードニング: [coccinelle](https://en.wikipedia.org/wiki/Coccinelle_(software)) のサポート <!-- Hardening: Add support for [coccinelle](https://en.wikipedia.org/wiki/Coccinelle_(software)) -->
+  ## ハードニング: [coccinelle](https://en.wikipedia.org/wiki/Coccinelle_(software)) のサポート <!-- Hardening: Add support for [coccinelle](https://en.wikipedia.org/wiki/Coccinelle_(software)) -->
   <!--
   LXC has gained support for the coccinelle code transformation tool. This allows us to automatically change code eliminating error caused by manually replacing e.g. deprecated functions such as `alloca()`.
   -->
   coccinelle コード解析（変形）ツールのサポートを追加しました。これによりコードを自動的に変更し、例えば `alloca()` のような使わない関数を手動で置き換える際のエラーを排除できます。
 
-  #### ハードニング: コンパイラベースのリソースクリーンアップ <!-- Hardening: Compiler based resource cleanup -->
+  ## ハードニング: コンパイラベースのリソースクリーンアップ <!-- Hardening: Compiler based resource cleanup -->
   <!--
   The codebase will be slowly switched over to make user of cleanup attributes supported by compilers such as `gcc` and `clang`.
   -->
   `gcc` や `clang` と言ったコンパイラがサポートするクリーンアップ属性を使用するために、コードベースはゆっくりと切り替わります。
 
-  #### ハードニング: コードベースから `fgets()` を削除 <!-- Hardening: Remove `fgets()` from the codebase -->
+  ## ハードニング: コードベースから `fgets()` を削除 <!-- Hardening: Remove `fgets()` from the codebase -->
   <!--
   To improve security all uses of `fgets()` have been removed from the codebase. Use of this function in new code is strongly discouraged.
   -->
   セキュリティの改善のため、`fgets()` をコードベースからすべて削除しました。今後、この関数を新たにコードで使用することは推奨しません。
 
-  #### ハードニング: Hardening: Expand close-on-exec usage
+  ## ハードニング: Hardening: Expand close-on-exec usage
   <!--
   All file descriptors that can be made close-on-exec are now close-on-exec.
   -->
   close-on-exec にできるファイルディスクリプタは、すべて close-on-exec になりました。
 
-  #### cgroup v2 で `/sys/kernel/cgroup/delegate` ファイルを使用 <!-- Use `/sys/kernel/cgroup/delegate` file for cgroup v2 -->
+  ## cgroup v2 で `/sys/kernel/cgroup/delegate` ファイルを使用 <!-- Use `/sys/kernel/cgroup/delegate` file for cgroup v2 -->
   <!--
   This  file  exports  a  list  of  the  cgroups  v2  files  (one  per line) that are delegatable (i.e., whose ownership  should  be  changed  to  the  user  ID  of  the delegatee). LXC will use this to determine how to correctly delegate cgroups.
   -->
   このファイルは委任可能な（つまり、所有権を委任者のユーザー ID に変更する必要がある） cgroup v2 ファイルの（1 行に 1 つの）リストを表示します。LXC はこのファイルを使い、正しく cgroup の委任を行う方法を決定します。
 
-  #### cgroup なしのレイアウトを扱う <!-- Handle layouts without cgroups -->
+  ## cgroup なしのレイアウトを扱う <!-- Handle layouts without cgroups -->
   <!--
   This lets LXC start containers on systems without writable cgroups.
   -->
   LXC は、書き込み可能な cgroup がない状態のシステムでコンテナを起動できます。
 
-  #### cpuset でオフラインの CPU を扱う <!-- Handle offline cpus in cpuset -->
+  ## cpuset でオフラインの CPU を扱う <!-- Handle offline cpus in cpuset -->
   <!--
   In addition to removing isolated cpus from a container's cgroup LXC will now also remove offline cpus from the container's cpuset.
   -->
   コンテナの cgroup から隔離する CPU を削除するのに加えて、LXC はコンテナの cpuset からオフラインの CPU も削除するようになりました。
 
-  #### コンテナごとに新しい boot id を生成 <!-- Generate new boot id for each container -->
+  ## コンテナごとに新しい boot id を生成 <!-- Generate new boot id for each container -->
   <!--
   LXC will now generate a new random boot id for each container and mount it to `/proc/sys/kernel/random/boot_id`. This will allow `systemd` to recognize the boots of each container.
   -->
   LXC は、コンテナごとに新たにランダムの boot id を生成し、それを `/proc/sys/kernel/random/boot_id` にマウントするようになりました。これで `systemd` が各コンテナのブートを認識できるようになりました。
 
-  #### 統一されたネットワーク作成 <!-- Unified network creation -->
+  ## 統一されたネットワーク作成 <!-- Unified network creation -->
   <!--
   LXC has a new unified way of creating networks for privileged and unprivileged containers greatly simplifying the code.
   -->
   LXC は特権コンテナであっても非特権コンテナであっても統一した方法でネットワークを作成し、コードを大幅に単純化します。
 
-  #### セキュリティ: [runC の CVE-2019-5736 に対する修正](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) <!-- Security: [Fix for runC CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) -->
+  ## セキュリティ: [runC の CVE-2019-5736 に対する修正](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) <!-- Security: [Fix for runC CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) -->
   <!--
   This release comes with  a fix for the privileged container breakout discovered earlier this year. As per our policy we don't consider privileged containers root safe and thus LXC as not received a CVE for this. However, we still provide a fix in this release. For more details see [this blog post](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container).
   -->
   このリリースでは、今年初めに発見された特権コンテナの脱獄に対する修正が含まれています。我々のポリシーでは、特権コンテナは安全であるとは考えていません。それゆえ LXC はこの CVE を受けていないと考えています。しかし、このリリースでは修正が含まれています。詳細については [このブログポスト](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container) をご覧ください。
 
-  ### バグ修正（翻訳なし） <!-- Bugfixes -->
+  # バグ修正（翻訳なし） <!-- Bugfixes -->
   - lxc-download: Pre-release bump of compat
   - seccomp: open memfd read-write
   - doc: Documents the lxc.net.[i].veth.mode option
@@ -437,11 +437,11 @@ content: |-
   - storage: do not destroy pre-existing rootfs
   - terminal: remove sigwinch command
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 3.2 isn't a LTS release and so will only be supported until such time as LXC 3.3 is released. We recommend users that need a stronger support commitment to stay on one of our LTS releases.
   -->
   LXC 3.2 は LTS リリースではありません。したがって、LXC 3.3 がリリースされるまでのみサポートされます。強力なサポートのコミットが必要なユーザーは LTS リリースを使い続けることをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - LXC リリース tarball <!-- LXC release tarball -->: [lxc-3.2.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.2.1.tar.gz) (GPG: [lxc-3.2.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.2.1.tar.gz.asc))

--- a/content/lxc/news.ja/lxc-4.0.0.yaml
+++ b/content/lxc/news.ja/lxc-4.0.0.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0 LTS リリースのお知らせ
 date: 2020/03/25 13:03
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.0!
   -->
@@ -13,9 +13,9 @@ content: |-
   -->
   このリリースは LXC 3.0.0 リリース以来 2 年に渡る作業の結果で、LXC プロジェクトにとって 4 つめの LTS リリースです。このリリースは 2025 年 6 月までサポートされます。
 
-  ### 主な変更点 <!-- Major changes -->
+  # 主な変更点 <!-- Major changes -->
 
-  #### cgroups: cgroup2 のフルサポート <!-- Full cgroup2 support -->
+  ## cgroups: cgroup2 のフルサポート <!-- Full cgroup2 support -->
   <!--
   LXC 4.0 now fully supports the unified cgroup hierarchy. For this to work the whole cgroup driver had to be rewritten. A consequence of this work is that the cgroup layout for LXC containers had to be changed. Older versions of LXC used the layout:
   -->
@@ -92,73 +92,73 @@ content: |-
   -->
   cgroup v2（単一）階層が強制する制限は、完全に非特権のコンテナを起動するには、cgroup を管理する init システムを使ったディストリビューションの協力が必要であるということも意味します。これは init システムとして systemd を使うすべてのディストリビューションに当てはまります。コンテナがシェルから `lxc-start` や他の手段で起動した場合、LXC が root cgroup にエスケープするために root になる必要があるか、もしくは init システムが空の cgroup を委任するように指示する必要があります。このようなシナリオでは、LXC が root cgroup へエスケープするのを防ぐように、`lxc.cgroup.relative` を `1` に設定するのが賢明です。
 
-  #### cgroups: cgroup v2 での freezer サポート <!-- Freezer support in CGroup2 -->
+  ## cgroups: cgroup v2 での freezer サポート <!-- Freezer support in CGroup2 -->
   <!--
   As part of the cgroup2 support work for LXC 4.0 we also added support for cgroup2's implementation of the freezer controller which allows to poll until the cgroup is frozen or unfrozen making freezing and unfreezing container's way more reliable than before.
   -->
   LXC 4.0 での cgroup v2 サポートの一部として、cgroup v2 の freezer コントローラー実装のサポートも追加しました。cgroup が凍結または解凍されるまでポーリングできるようになり、コンテナの凍結と解凍が以前より信頼性が以前より増しました。
 
-  #### cgroups: cgroup v2 での eBPF デバイスコントローラーのサポート <!-- eBPF device controller support in CGroup2 -->
+  ## cgroups: cgroup v2 での eBPF デバイスコントローラーのサポート <!-- eBPF device controller support in CGroup2 -->
   <!--
   LXC 4.0 can now make proper use of the cgroup2 device controller. It will automatically create, load, and attach a eBPF program to the container's cgroup and supports dynamic additional and removal of rules. The configuration format is the same as for the legacy cgroup controller. Only the `lxc.cgroup2.devices.` prefix instead of the legacy `lxc.cgroup.devices` prefix needs to be used. LXC continues to support both black- and whitelists.
   -->
   LXC 4.0 は cgroup v2 のデバイスコントローラーをより適切に利用できるようになりました。これはコンテナの cgroup の作成、ロード、eBPF プログラムのアタッチが自動的に行われ、ルールの動的な追加・削除をサポートします。設定フォーマットは cgroup v1 コントローラーのものと同じです。`lxc.cgroup.devices` の代わりに `lxc.cgroup2.devices` だけを使う必要があります。LXC はブラックリストとホワイトリストの両方をサポートし続けます。
 
-  #### AppArmor: `/proc/acpi/**` へのアクセス拒否 <!-- Deny access to `/proc/acpi/**` -->
+  ## AppArmor: `/proc/acpi/**` へのアクセス拒否 <!-- Deny access to `/proc/acpi/**` -->
   <!--
   The default AppArmor profile now denies access to `/proc/acpi/` improving safety.
   -->
   デフォルトの AppArmor プロファイルは、安全性の向上のために `/proc/acpi` へのアクセスを拒否するようになりました。
 
-  #### config: `lxc.autodev.tmpfs.size` 設定キーの追加 <!-- Add `lxc.autodev.tmpfs.size` configuration key -->
+  ## config: `lxc.autodev.tmpfs.size` 設定キーの追加 <!-- Add `lxc.autodev.tmpfs.size` configuration key -->
   <!--
   LXC supports creating a usable minimal `/dev` directory for the container by setting `lxc.autodev = 1` in the container's config file. To do this LXC sets up a `tmpfs` mount on `/dev`. This `tmpfs` mount could not be restricted in prior releases. Now it is possible to set a limit on the size of the `tmpfs` mount by setting `lxc.autodev.tmpfs.size` to the number of bytes that the `tmpfs` should be restricted to use.
   -->
   LXC はコンテナが使用可能な最小の `/dev` ディレクトリの作成をサポートしています。これは `lxc.autodev = 1` で設定します。この作成のために、LXC は `/dev` に `tmpfs` マウントを設定します。この `tmpfs` マウントはこれまでのバージョンでは制限できませんでした。この `tmpfs` マウントのサイズ制限が設定できるようになりました。これは `lxc.autodev.tmpfs.size` に `tmpfs` が使用する制限をバイト数で設定します。
 
-  #### config: `lxc.selinux.context.keyring` 設定キーの追加 <!-- Add `lxc.selinux.context.keyring` key -->
+  ## config: `lxc.selinux.context.keyring` 設定キーの追加 <!-- Add `lxc.selinux.context.keyring` key -->
   <!--
   This allows to specify the `selinux` context to be used for the keyring the container uses.
   -->
   この設定で、コンテナが使うキーリングに使う `selinux` コンテキストを指定できます。
 
-  #### config: `lxc.keyring.session`　設定キーの追加 <!-- Add `lxc.keyring.session` -->
+  ## config: `lxc.keyring.session`　設定キーの追加 <!-- Add `lxc.keyring.session` -->
   <!--
   Setting this to `1` (default) will cause LXC to create a new session keyring.
   -->
   これを `1` （デフォルト）に設定すると LXC に新しいセッションキーリングを作成します。
 
-  #### file utils: `fopen_cached()` と `fdopen_cached` の追加 <!-- Add `fopen_cached()` and `fdopen_cached` -->
+  ## file utils: `fopen_cached()` と `fdopen_cached` の追加 <!-- Add `fopen_cached()` and `fdopen_cached` -->
   <!--
   These helpers first read a whole file and then make it available as a stream to be read via regular file-based libc apis. This makes LXC's handling of various files more robust where the underlying file can change while it is read.
   -->
   これらのヘルパーは、最初に全ファイルを読み込み、通常のファイルベースの libc API 経由で読むためにストリームとして使えるようにします。これにより、読み込まれている間に元となるファイルが変更される可能性がある場合に、LXC のさまざまなファイルの扱いがより強固になります。
 
-  #### api: 新しい `init_pidfd()` メンバーの追加 <!-- Add new `init_pidfd()` member -->
+  ## api: 新しい `init_pidfd()` メンバーの追加 <!-- Add new `init_pidfd()` member -->
   <!--
   LXC 4.0 fully supports the new pidfd kernel api the LXC team has merged in the upstream Linux kernel. The `pidfd` of the container's init process can be requested via `c->init_pidfd(c)`.
   -->
   LXC 4.0 では、LXC チームがアップストリームのカーネルにマージした新しい pidfd カーネル API を完全にサポートします。コンテナの init プロセスの `pidfd` は `c->init_pidfd(c)` 経由でリクエストできます。
 
-  #### memory utils: Add new cleanup api
+  ## memory utils: Add new cleanup api
   <!--
   LXC 4.0 expands the usage of the compiler's cleanup attribute by introducing new internal apis to define and call cleanup macros for complex resource allocations. We have had extremely positive results decreasing bugs around file descriptor and memory leaks significantly by switching to this new way of cleaning up resources.
   -->
   LXC 4.0 で、複雑なリソース割り当てのためのクリーンアップマクロを定義し、呼ぶための新しい内部 API を導入し、コンパイラーのクリーンアップ属性の使用を拡張しました。このリソースクリーンアップの新しい方法に切り替えることで、ファイルディスクリプターとメモリーリークが大幅に減少し、非常に良い結果が得られました。
 
-  #### lxc-usernsexec: 自身の uid をマップするのが簡単に <!-- Make it easy to map own uid -->
+  ## lxc-usernsexec: 自身の uid をマップするのが簡単に <!-- Make it easy to map own uid -->
   <!--
   The `lxc-usernsexec` binary now finds a default mapping as specified in `/etc/subuid` and `/etc/subgid` and writes it via `newuidmap` and `newgidmap`.
   -->
   `lxc-usernsexec` バイナリーは `/etc/subuid` と `/etc/subgid` で指定するデフォルトのマッピングを参照し、それを `newuidmap` と `newgidmap` で書くようになりました。
 
-  #### seccomp: s390 サポートの追加 <!-- Add s390 support -->
+  ## seccomp: s390 サポートの追加 <!-- Add s390 support -->
   <!--
   LXC 4.0's seccomp implementation now supports s390 as architecture.
   -->
   LXC 4.0 の seccomp 実装はアーキテクチャーとして s390 をサポートするようになりました。
 
-  #### syscalls: マニュアルでのシステムコール実装を改良 <!-- Improve manual syscall implementations -->
+  ## syscalls: マニュアルでのシステムコール実装を改良 <!-- Improve manual syscall implementations -->
   <!--
   Whenever a given syscall is not supported or exposed by the underlying `C` library of the system LXC will define syscall stubs for important syscalls or new features it deems extremely valuable. This used to be done by checking for `__NR_<syscall-name>` being defined. But `__NR_<syscall-name>` being defined depended on the correct headers for the currently running kernel LXC was compiled on being installed and would be problematic whenever LXC was compiled on a system running an older kernel but used or deployed on systems that use a new kernel. In such scenarios LXC could not make use of new kernel features even though it should. We now introduce definitions for `__NR_<syscall-name>` whenever the system does not define it already and it is an architecture we support (which is basically any architecture). This way we better handle kernel <-> header version mismatches and compilation <-> deployment kernel mismatches.
   -->
@@ -166,19 +166,19 @@ content: |-
 
   システムがまだ定義しておらず、我々がサポートするアーキテクチャーである場合（基本的にどのようなアーキテクチャーであっても）、`__NR_<syscall-name>` を定義するようにしました。この方法で、カーネルとヘッダーのバージョン、コンパイルとインストールする環境のカーネルのミスマッチをより良く扱えるようになりました。
 
-  #### network: ネットワークデバイスの作成と削除の改良 <!-- Improved network device creation and removal -->
+  ## network: ネットワークデバイスの作成と削除の改良 <!-- Improved network device creation and removal -->
   <!--
   We have reworked how network devices are created, tracked, moved between network namespaces, and are removed making low-level network management way more reliable.
   -->
   ネットワークデバイスの作成方法、追跡方法、ネットワーク名前空間の間の移動方法、削除方法を再構築し、低レベルのネットワーク管理方法をより信頼性の高いものにしました。
 
-  #### network: ワイヤレスデバイスの移動が可能に <!-- Allow moving wireless devices -->
+  ## network: ワイヤレスデバイスの移動が可能に <!-- Allow moving wireless devices -->
   <!--
   LXC allowed to move wireless network devices (`nl80211`) into containers. This was broken for a while. With 4.0 the abilito to move wireless network devices is restored and improved.
   -->
   LXC でワイヤレスネットワークデバイス（`nl80211`）をコンテナ内に移動できるようになりました。これはしばらくの間壊れていました。4.0 でワイヤレスネットワークを移動する機能が復活し、改良されました。
 
-  ### 完全な ChangeLog（翻訳なし） <!-- Complete changelog -->
+  # 完全な ChangeLog（翻訳なし） <!-- Complete changelog -->
   Here is a complete list of all changes in this release:
 
   - cgroups: fix attaching to the unified cgroup
@@ -476,7 +476,7 @@ content: |-
   - Use file/directory names from macro.h
   - tree-wide: fix wrong copy-paste for licenses
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 4.0.0 will be supported until June 2025 and our current LTS release, LXC 3.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
   -->
@@ -487,12 +487,12 @@ content: |-
   -->
   すべての LXC ユーザーは 4.0 ブランチへのアップグレードを計画することを強く推奨します。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.0.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxc-4.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.0.tar.gz.asc)
 
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXC 4.0.0 release was brought to you by a total of 30 contributors.
   -->

--- a/content/lxc/news.ja/lxc-4.0.1.yaml
+++ b/content/lxc/news.ja/lxc-4.0.1.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.1 LTS リリースのお知らせ
 date: 2020/04/06 20:04
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-1-lts-has-been-released/7310
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.1!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対するはじめてのバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   This release fixes a number of issues that were reported shortly following the [original 4.0.0 release](https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182). Some of the highlights include:
   -->
@@ -72,7 +72,7 @@ content: |-
    - lxccontainer: poll takes millisecond not seconds
    - Revert "start: remove unnecessary check for valid cgroup_ops"
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -80,7 +80,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.1.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.1.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.10.yaml
+++ b/content/lxc/news.ja/lxc-4.0.10.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.10 リリースのお知らせ
 date: 2021/07/17 03:07
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-10-has-been-released/11618
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.10!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 10 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
   -->
@@ -108,7 +108,7 @@ content: |-
    - af_unix: report error when no fd is to be sent
    - terminal: fix error handling
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -116,7 +116,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.10.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.10.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.10.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.10.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.11.yaml
+++ b/content/lxc/news.ja/lxc-4.0.11.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.11 リリースのお知らせ
 date: 2021/10/19 21:10
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-11-has-been-released/12427
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.11!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 11 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
   -->
@@ -315,7 +315,7 @@ content: |-
    - conf: verify that rootfs is stable after setting up mounts
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -323,7 +323,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.11.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.11.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.11.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.11.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.12.yaml
+++ b/content/lxc/news.ja/lxc-4.0.12.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.12 リリースのお知らせ
 date: 2022/02/02 23:02
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-12-has-been-released/13288
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.12!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 12 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
   -->
@@ -93,7 +93,7 @@ content: |-
    - lxccontainer: allow xdev when creating the container dir
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -101,7 +101,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.12.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.12.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.12.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.12.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.2.yaml
+++ b/content/lxc/news.ja/lxc-4.0.2.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.2 LTS リリースのお知らせ
 date: 2020/04/16 19:04
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-2-lts-has-been-released/7449
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.2!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 2 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   This release fixes a number of issues that were reported shortly following the original [4.0.0](https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182) and [4.0.1](https://discuss.linuxcontainers.org/t/lxc-4-0-1-lts-has-been-released/7310) releases. Some of the highlights include:
   -->
@@ -68,7 +68,7 @@ content: |-
    - cgroups: fix cgroup limit braino
    - configure: fix coverity builds
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -76,7 +76,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.2.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.2.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.3.yaml
+++ b/content/lxc/news.ja/lxc-4.0.3.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.3 LTS リリースのお知らせ
 date: 2020/06/29 14:06
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-3-lts-has-been-released/8285
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.3!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 3 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -97,7 +97,7 @@ content: |-
    - lxc-net: Set broadcast
    - commands: don't flood logs
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -105,7 +105,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.3.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.3.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.4.yaml
+++ b/content/lxc/news.ja/lxc-4.0.4.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.4 LTS リリースのお知らせ
 date: 2020/08/04 21:08
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-4-lts-has-been-released/8624
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.4!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 4 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -108,7 +108,7 @@ content: |-
    - syscall: don't fail if __NR_signalfd is not defined
    - conf: ensure that the idmap pointer itself is freed
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -116,7 +116,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.4.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.4.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.5.yaml
+++ b/content/lxc/news.ja/lxc-4.0.5.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.5 LTS has been released
 date: 2020/10/22 17:10
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-5-lts-has-been-released/9269
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.5!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 5 回目のバグフィックスリリースです。
 
-  ### バグ修正（とハイライト）<!-- Bugfixes -->
+  # バグ修正（とハイライト）<!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -72,7 +72,7 @@ content: |-
    - conf: always send response to parent waiting for devptfs_fd
    - conf: account for early return when sending devpts fd
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -80,7 +80,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.5.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.5.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.5.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.5.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.6.yaml
+++ b/content/lxc/news.ja/lxc-4.0.6.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.6 LTS リリースのお知らせ <!-- LXC 4.0.6 LTS has been rel
 date: 2021/01/12 20:01
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-6-lts-has-been-released/9926
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.6!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは 2025 年 6 月までサポートされる LXC 4.0 に対する 6 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
   -->
@@ -246,7 +246,7 @@ content: |-
    - Changed Version from 2.*.* to 4.*.*
    - make lxc-net hermetic w.r.t. existing dnsmasq config
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -254,7 +254,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.6.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.6.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.6.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.6.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-4.0.9.yaml
+++ b/content/lxc/news.ja/lxc-4.0.9.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.9 LTS リリースのお知らせ <!-- LXC 4.0.9 LTS has been rel
 date: 2021/05/06 17:05
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-9-lts-has-been-released/10999
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 4.0.9!
   -->
@@ -23,7 +23,7 @@ content: |-
   -->
   以下の変更は 4.0.6 から 4.0.9 までの変更を含みます。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
   -->
@@ -832,7 +832,7 @@ content: |-
    - conf: add personality_t
    - attach: introduce explicit personality macro
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -840,7 +840,7 @@ content: |-
   LXC 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-4.0.9.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.9.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-4.0.9.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.9.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-5.0.0.yaml
+++ b/content/lxc/news.ja/lxc-5.0.0.yaml
@@ -2,7 +2,7 @@ title: LXC 5.0 LTS リリースのお知らせ
 date: 2022/06/17 17:06
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-lts-has-been-released/14381
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 5.0.0!
   -->
@@ -13,8 +13,8 @@ content: |-
   -->
   このリリースは LXC 4.0.0 リリース以来の 2 年間の作業の成果で、LXC プロジェクトの 5 回目の LTS リリースです。このリリースは 2027 年 6 月までサポートされます。
 
-  ### 主な変更点 <!-- Major changes -->
-  #### meson への切り替え <!-- Switch to meson -->
+  # 主な変更点 <!-- Major changes -->
+  ## meson への切り替え <!-- Switch to meson -->
   <!--
   With this release of LXC, autotools is being replaced by `meson` as the build tooling. Compatibility `Makefile` targets are provided for `all`, `install` and `dist`.
   -->
@@ -25,7 +25,7 @@ content: |-
   -->
   この変更は特にパッケージ作成者に関係する変更で、それ以外、ユーザーには目に見える影響はありません。
 
-  #### 新しい cgroup 設定オプション <!-- New cgroup configuration options -->
+  ## 新しい cgroup 設定オプション <!-- New cgroup configuration options -->
   <!--
   Four new options were added:
   -->
@@ -41,7 +41,7 @@ content: |-
   -->
   これにより、コンテナ自身、モニタープロセス、コンテナ終了時のモニタープロセスが使う cgroup パスが正確にコントロールできるようになります。そして、コンテナの cgroup をネストした（内部の）cgroup 内に配置することもできます。
 
-  #### Time namespace サポート <!-- Time namespace support -->
+  ## Time namespace サポート <!-- Time namespace support -->
   <!--
   LXC now supports setting up the time namespace.
   This is done through two new options:
@@ -56,7 +56,7 @@ content: |-
   -->
   これは、メインシステムクロックにオフセット（数ナノ秒から数時間）を適用します。
 
-  #### VETH デバイスに対する VLAN サポート <!-- VLAN support on VETH devices -->
+  ## VETH デバイスに対する VLAN サポート <!-- VLAN support on VETH devices -->
   <!--
   Two new config options were added to the VETH network devices to control VLAN tagging.
   -->
@@ -70,7 +70,7 @@ content: |-
   -->
   前者はプライマリー（タグなし）VLAN を設定します。後者はデバイスに追加のタグ付き VLAN を設定するのに使います。これは親のブリッジデバイスで VLAN フィルタリングの使用を要求します。
 
-  #### VETH デバイスで送受信キューが設定可能に <!-- Configurable transmit/receive queues on VETH devices -->
+  ## VETH デバイスで送受信キューが設定可能に <!-- Configurable transmit/receive queues on VETH devices -->
   <!--
   Still on VETH devices. It's now possible to customize the number of receive and transmit queues through two new configuration options:
   -->
@@ -80,7 +80,7 @@ content: |-
    - veth.n_txqueues
 
 
-  ### 完全な ChangeLog（翻訳なし）<!-- Complete changelog -->
+  # 完全な ChangeLog（翻訳なし）<!-- Complete changelog -->
   <!--
   Here is a complete list of all changes in this release:
   -->
@@ -1940,7 +1940,7 @@ content: |-
    - meson: Fix bad strerror_r check
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 5.0 will be supported until June 2027 and our current LTS release, LXC 4.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
   -->
@@ -1951,12 +1951,12 @@ content: |-
   -->
   すべての LXC ユーザーは 5.0 ブランチへのアップグレードを計画することを強く推奨します。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-5.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.0.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxc-5.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.0.tar.gz.asc)
 
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXC 5.0 release was brought to you by a total of 65 contributors.
   -->

--- a/content/lxc/news.ja/lxc-5.0.1.yaml
+++ b/content/lxc/news.ja/lxc-5.0.1.yaml
@@ -2,7 +2,7 @@ title: LXC 5.0.1 リリースのお知らせ
 date: 2022/07/28 22:07
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-1-has-been-released/14724
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 5.0.1!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは LXC 5.0 の最初のバグ修正リリースです。このリリースは 2027 年 6 月までサポートされます。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening.
   Some of the highlights for this release are:
@@ -48,7 +48,7 @@ content: |-
    - README: update security mails
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -56,7 +56,7 @@ content: |-
   LXC 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-5.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.1.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-5.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.1.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-5.0.2.yaml
+++ b/content/lxc/news.ja/lxc-5.0.2.yaml
@@ -2,7 +2,7 @@ title: LXC 5.0.2 LTS リリースのお知らせ
 date: 2023/01/20 19:01
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-2-lts-has-been-released/16210
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 5.0.2!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは LXC 5.0 の 2 回目のバグ修正リリースです。このリリースは 2027 年 6 月までサポートされます。
 
-  ### 脆弱性の修正 <!-- Security fix -->
+  # 脆弱性の修正 <!-- Security fix -->
   <!--
   This release does fix one CVE which was recently open against LXC.
   [CVE-2022-47952](https://nvd.nist.gov/vuln/detail/CVE-2022-47952) covers the use of `lxc-user-nic` (setuid binary) as a way to uncover the existence of files at locations which would normally not be accessible to the user.
@@ -26,7 +26,7 @@ content: |-
   -->
   この問題は CVE で low severity に分類され、修正とともに GitHub を通して公に報告されました。これは制限（embargo）下でリリースされておらず、この問題の影響が低いことを考慮して、liblxc に対する他のバグ修正と同様にこの問題を処理することに決定しました。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening.
   -->
@@ -110,7 +110,7 @@ content: |-
    - Fix build error on sparc64 caused by using the gold linker
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -118,7 +118,7 @@ content: |-
   LXC 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-5.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.2.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-5.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.2.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-5.0.3.yaml
+++ b/content/lxc/news.ja/lxc-5.0.3.yaml
@@ -2,7 +2,7 @@ title: LXC 5.0.3 LTS リリースのお知らせ
 date: 2023/07/25 22:07
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-3-lts-has-been-released/17708
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 5.0.3!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   このリリースは LXC 5.0 の 3 回目のバグ修正リリースです。このリリースは 2027 年 6 月までサポートされます。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   As usual this bugfix releases focus on stability and hardening.
   -->
@@ -60,7 +60,7 @@ content: |-
    - github: Update for main branch
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXC 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -68,7 +68,7 @@ content: |-
   LXC 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード<!-- Downloads -->
+  # ダウンロード<!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-5.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.3.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-5.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.3.tar.gz.asc)

--- a/content/lxc/news.ja/lxc-6-0-lts-has-been-released.yaml
+++ b/content/lxc/news.ja/lxc-6-0-lts-has-been-released.yaml
@@ -2,7 +2,7 @@ title: LXC 6.0 LTS リリースのお知らせ
 date: 2024/04/03 20:04
 origin: https://discuss.linuxcontainers.org/t/lxc-6-0-lts-has-been-released/19567
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXC team is pleased to announce the release of LXC 6.0 LTS!
   -->
@@ -13,8 +13,8 @@ content: |-
   -->
   これは LXC 5.0 のリリース以来 2 年の作業の成果です。そして、LXC プロジェクトの 6 回目の LTS リリースです。このリリースは 2029 年 6 月までサポートされます。
 
-  ### ハイライト <!-- Highlights -->
-  #### 新しいマルチコールバイナリー <!-- New multi-call binary -->
+  # ハイライト <!-- Highlights -->
+  ## 新しいマルチコールバイナリー <!-- New multi-call binary -->
   <!--
   A new `tools-multicall=true` configuration option can be used to produce a single `lxc` binary which can then have all other `lxc-XYZ` commands be symlinked to.
   -->
@@ -25,7 +25,7 @@ content: |-
   -->
   これにより、大幅にディスクスペースを削減でき、特に組み込みプラットフォームで有用です。
 
-  #### ライブラリーへの `set_timeout` 関数の追加 <!-- Add a `set_timeout` function to the library -->
+  ## ライブラリーへの `set_timeout` 関数の追加 <!-- Add a `set_timeout` function to the library -->
   <!--
   A new `set_timeout` function is available on the main `lxc_container` struct and allow for setting a global timeout for interactions with the LXC monitor.
   -->
@@ -41,19 +41,19 @@ content: |-
   -->
   この新しいシンボルをライブラリーに追加した結果、liblxc のシンボルバージョンが 1.8.0 に上がりました。
 
-  #### LXC ブリッジで IPv6 が有効に <!-- LXC bridge now has IPV6 enabled -->
+  ## LXC ブリッジで IPv6 が有効に <!-- LXC bridge now has IPV6 enabled -->
   <!--
   The default `lxcbr0` bridge now comes with IPv6 enabled by default, using an IPv6 ULA subnet.
   -->
   デフォルトの `lxcbr0` ブリッジは、IPv6 ULA サブネットを使い、デフォルトで IPv6 が有効になりました。
 
-  #### `lxc-usernsexec` の uid/gid 選択のサポート <!-- Support for uid/gid selection in `lxc-usernsexec` -->
+  ## `lxc-usernsexec` の uid/gid 選択のサポート <!-- Support for uid/gid selection in `lxc-usernsexec` -->
   <!--
   The `lxc-usernsexec` tool now has both `-u` and `-g` options to control what resulting UID and GID (respectively) the user wishes to use (defaulting to 0/0).
   -->
   `lxc-usernsexec` ツールに、ユーザーが使いたい UID と GID それぞれを制御するための `-u` と `-g` オプションが追加されました（デフォルトは 0/0 です）。
 
-  #### `lxc-checkconfig` の改良 <!-- Improvements to `lxc-checkconfig` -->
+  ## `lxc-checkconfig` の改良 <!-- Improvements to `lxc-checkconfig` -->
   <!--
   `lxc-checkconfig` now only shows the version if `lxc-start` is present (rather than failing).
   Additionally, it's seen a number of other cosmetic improvements as well as now listing the maximum number of allowed namespaces for every namespace type.
@@ -61,13 +61,13 @@ content: |-
   `lxc-checkconfig` は、（失敗するのではなく）`lxc-start` が存在するときだけ、バージョンを表示するようになりました。
   さらに、各 Namespace タイプごとに使える名前空間の最大数をリストするだけでなく、その他の見た目の改良も多数行われています。
 
-  #### squashfs OCI イメージのサポート <!-- Support for squashfs OCI images -->
+  ## squashfs OCI イメージのサポート <!-- Support for squashfs OCI images -->
   <!--
   The built-in `oci` container template can now handle `squashfs` compressed OCI images through the use of `atomfs`.
   -->
   ビルトインの `oci` コンテナテンプレートは、`atomfs` を使用し、`squashfs` 圧縮された OCI イメージを処理できるようになりました。
 
-  #### systemd の dbus から dbus-1 への変更 <!-- Switched from systemd's dbus to dbus-1 -->
+  ## systemd の dbus から dbus-1 への変更 <!-- Switched from systemd's dbus to dbus-1 -->
   <!--
   LXC now uses `libdbus-1` for DBus interactions with systemd rather than using `libsystemd`.
   The reason for this change is that `libdbus-1` is readily available for static builds.
@@ -75,7 +75,7 @@ content: |-
   LXC は systemd との DBus でのやりとりに `libsystemd` ではなく、`libdbus-1` を使うようになりました。
   この理由は、`libdbus-1` は静的ビルドですぐに使えるためです。
 
-  #### Upstart サポートの削除 <!-- Removed Upstart support -->
+  ## Upstart サポートの削除 <!-- Removed Upstart support -->
   <!--
   Support for the `Upstart` init system has finally been removed from LXC.
   -->
@@ -86,7 +86,7 @@ content: |-
   -->
   この削除は、現段階では誰にも影響しないはずです。そして、リポジトリーからいくつかのロジックと構成ファイルをクリーンアップできます。
 
-  ### すべての変更点（翻訳なし） <!-- Full changelog -->
+  # すべての変更点（翻訳なし） <!-- Full changelog -->
 
   [details="すべてのChangelogを見る"]
    - Read list until process exits
@@ -296,7 +296,7 @@ content: |-
    - lxc.spec: Align SPDX license id
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXC 6.0 will be supported until June 2029 and our current LTS release, LXC 5.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
   -->
@@ -307,7 +307,7 @@ content: |-
   -->
   LXC のユーザーはすべて、6.0 ブランチをアップグレードを計画することを強くおすすめします。
 
-  ### 今後のリリースについて <!-- Future release cadence -->
+  # 今後のリリースについて <!-- Future release cadence -->
   <!--
   To make new LXC features more readily available to users, we have decided to start producing non-LTS releases again. The planned interval is every 6 months with LXC 6.1 planned for October.
   -->
@@ -323,12 +323,12 @@ content: |-
   -->
   本番環境のユーザーは LTS リリースを利用し続けたいと思うでしょう。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxc-6.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-6.0.0.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxc-6.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-6.0.0.tar.gz.asc)
 
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXC 6.0 release was brought to you by a total of 56 contributors.
   -->

--- a/content/lxc/news/lxc-1.0.0.yaml
+++ b/content/lxc/news/lxc-1.0.0.yaml
@@ -1,7 +1,7 @@
 title: LXC 1.0.0 release announcement
 date: 2014/02/20 00:00
 content: |-
-  ### Introduction
+  # Introduction
   It's with great pleasure that the LXC team is announcing the release of LXC 1.0!
   
   This release is a significant milestone for us as it marks the first release we consider to be production ready.
@@ -13,14 +13,14 @@ content: |-
   cellphones and cloud instances. And we are confident that with LXC 1.0, we will see LXC's usage expand even more
   and be used for a lot of new and exciting projects.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.
   
   Should you be interested in individual changes or just looking at the detailed development history,
   our main repository is on [GitHub](https://github.com/lxc/lxc).
   
-  ### New features
+  # New features
   LXC 1.0 is the result of 10 months of development and over a thousand commits, including a major rework of the way LXC is structured.
   It's therefore near impossible to come up with a comprehensive list of changes in this release,
   however here are some highlights:
@@ -46,7 +46,7 @@ content: |-
   A series of blog posts introducing you to LXC and highlighting some of LXC 1.0's new features may be found [here](https://www.stgraber.org/2013/12/20/lxc-1-0-blog-post-series/).
   
   
-  ### LXC 1.0 moving forward
+  # LXC 1.0 moving forward
   LXC 1.0 is the first production ready release of LXC and it comes with a commitment from upstream
   to maintain it until at least Ubuntu 14.04 LTS reaches end of life in April 2019.
   That's slightly over 5 years of support!
@@ -55,7 +55,7 @@ content: |-
   It's expected that we will have frequent bugfix releases of 1.0 so distributions can simply use those
   and save themselves the trouble of having to manually follow our stable branch.
   
-  ### Bug reports and contact information
+  # Bug reports and contact information
   Bug reports should be filed on [GitHub](https://github.com/lxc/lxc/issues) or if you do not wish to create an account, by e-mail to the appropriate [mailing-list](https://lists.linuxcontainers.org).
   The same goes for your patches. We tend to prefer patches sent to lxc-devel but we also accept pull request directly on GitHub.
   

--- a/content/lxc/news/lxc-1.0.1.yaml
+++ b/content/lxc/news/lxc-1.0.1.yaml
@@ -3,7 +3,7 @@ date: 2014/03/06 00:00
 content: |-
   This is the first bugfix release for the LXC 1.0 series.
   
-  ### Changes
+  # Changes
   
   Core:
   
@@ -39,7 +39,7 @@ content: |-
    * tests: Fix potential hang in lxc-test-concurent
    * upstart: Don't forward requests for LXC\_DOMAIN (dnsmasq)
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.1.
   

--- a/content/lxc/news/lxc-1.0.10.yaml
+++ b/content/lxc/news/lxc-1.0.10.yaml
@@ -50,7 +50,7 @@ content: |-
    * commands: non-functional changes
    * lxccontainer: avoid NULL pointer dereference
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.10.
   

--- a/content/lxc/news/lxc-1.0.11.yaml
+++ b/content/lxc/news/lxc-1.0.11.yaml
@@ -57,7 +57,7 @@ content: |-
    * utils: Fix the bug of 'ts-\>stdoutfd' did not fill with parameters 'stdoutfd'
    * utils: Remove dead assignments in lxc\_popen()
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.11.
   

--- a/content/lxc/news/lxc-1.0.2.yaml
+++ b/content/lxc/news/lxc-1.0.2.yaml
@@ -3,7 +3,7 @@ date: 2014/03/27 00:00
 content: |-
   This is the second bugfix release for the LXC 1.0 series.
   
-  ### Changes
+  # Changes
   
   Core:
   
@@ -52,7 +52,7 @@ content: |-
    * fedora template: Fix building i686 containers on x86\_64
    * opensuse template: Fix syntax error
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.2.
   

--- a/content/lxc/news/lxc-1.0.3.yaml
+++ b/content/lxc/news/lxc-1.0.3.yaml
@@ -3,7 +3,7 @@ date: 2014/04/08 00:00
 content: |-
   This is the third bugfix release for the LXC 1.0 series.
   
-  ### Changes
+  # Changes
   
   Core:
   
@@ -45,7 +45,7 @@ content: |-
    * tests: Bump timeouts to fix occasional failures on slow ARM builders.
    * tests: Always propagate http\_proxy and https\_proxy.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.3.
   

--- a/content/lxc/news/lxc-1.0.4.yaml
+++ b/content/lxc/news/lxc-1.0.4.yaml
@@ -3,7 +3,7 @@ date: 2014/06/13 00:00
 content: |-
   This is the fourth bugfix release for the LXC 1.0 series.
   
-  ### Changes
+  # Changes
   
   Core:
   
@@ -104,7 +104,7 @@ content: |-
   
   Those stable fixes were brought to you by 14 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.4.
   

--- a/content/lxc/news/lxc-1.0.5.yaml
+++ b/content/lxc/news/lxc-1.0.5.yaml
@@ -3,7 +3,7 @@ date: 2014/07/14 00:00
 content: |-
   This is the fifth bugfix release for the LXC 1.0 series.
   
-  ### seccomp profile
+  # seccomp profile
   Outside of the usual bugfixes, this release also introduces one important change.
   For systems where LXC is built with seccomp support, containers will now have a seccomp profile enabled
   which will prevent calls to the following syscalls:
@@ -25,7 +25,7 @@ content: |-
   If you want to manually turn this on for a container which doesn't use the common config mechanism,
   you can add something like "lxc.seccomp = /usr/share/lxc/config/common.seccomp" to the container configuration.
   
-  ### Changes
+  # Changes
   
   Core:
   
@@ -75,7 +75,7 @@ content: |-
   
   Those stable fixes were brought to you by 11 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.5.
   

--- a/content/lxc/news/lxc-1.0.6.yaml
+++ b/content/lxc/news/lxc-1.0.6.yaml
@@ -7,7 +7,7 @@ content: |-
   This argument is a no-op as lxc-start is already running in the foreground by default, but as that behavior will change in LXC 1.1,
   introducing -F in 1.0 too allows for writing script which will work consistently on upgrades.
   
-  ### Changes
+  # Changes
   Core:
   
    * rootfs\_is\_blockdev: don't run if no rootfs is specified
@@ -107,7 +107,7 @@ content: |-
   
   Those stable fixes were brought to you by 24 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.6.
   

--- a/content/lxc/news/lxc-1.0.7.yaml
+++ b/content/lxc/news/lxc-1.0.7.yaml
@@ -3,7 +3,7 @@ date: 2014/12/05 00:00
 content: |-
   This is the seventh bugfix release for the LXC 1.0 series.
   
-  ### Changes
+  # Changes
   
   Core:
   
@@ -90,7 +90,7 @@ content: |-
   
   Those stable fixes were brought to you by 27 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.7.
   

--- a/content/lxc/news/lxc-1.0.8.yaml
+++ b/content/lxc/news/lxc-1.0.8.yaml
@@ -199,7 +199,7 @@ content: |-
   
   Those stable fixes were brought to you by 59 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.8.
   

--- a/content/lxc/news/lxc-1.0.9.yaml
+++ b/content/lxc/news/lxc-1.0.9.yaml
@@ -152,7 +152,7 @@ content: |-
    * tree-wide: replace readdir\_r() with readdir()
    * attach: do not send procfd to attached process
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.0.9.
   

--- a/content/lxc/news/lxc-1.1.0.yaml
+++ b/content/lxc/news/lxc-1.1.0.yaml
@@ -13,7 +13,7 @@ content: |-
   While not strictly required, it is recommended that LXC 1.1 be used with cgmanager 0.35 (or higher)
   and lxcfs 0.5 (or higher).
   
-  ### Highlights
+  # Highlights
   LXC 1.1 introduces checkpoint/restore support for containers through CRIU.
   This allows to serialize the container running state to disk, for live migration or for later local restoration
   of the container.
@@ -28,7 +28,7 @@ content: |-
   
   This release was made possible by contributions from 84 developers.
   
-  ### New features
+  # New features
    * lxc-autostart: New -A/--ignore-auto flag (starts all containers)
    * lxc-ls: New "interface" field
    * centos/fedora: Added a root\_password\_expired environment variable (defaults to yes)
@@ -59,7 +59,7 @@ content: |-
    * core: A new common.conf.d configuration directory is available for users and packages to drop configuration snippets to be applied to all containers
    * core: The container\_ttys environment variable is now set by LXC
   
-  ### Change in behavior
+  # Change in behavior
    * lxc-create now requires be passed (-t), use "none" for the old behavior.
    * snapshots are now stored in the container's directory
    * lxc.arch for PER\_LINUX32 is now output as i686
@@ -73,7 +73,7 @@ content: |-
    * core: clear\_config\_item now exclusively affects lists (lxc\_list) entries. set\_config\_item should be used for anything else.
    * templates: All templates now use lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed (safe default configuration)
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.0, unless they decide to stick to the long term 1.0 release.
   

--- a/content/lxc/news/lxc-1.1.1.yaml
+++ b/content/lxc/news/lxc-1.1.1.yaml
@@ -3,7 +3,7 @@ date: 2015/03/16 00:00
 content: |-
   This is the first bugfix release for LXC 1.1.
   
-  ### Changes
+  # Changes
   
    * config: Allow FUSE access by default (instead of individually in most templates)
    * Make /proc/sys/net writable when using proc:mixed (required for network config)
@@ -21,7 +21,7 @@ content: |-
   
   Those stable fixes were brought to you by 13 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.1.
   

--- a/content/lxc/news/lxc-1.1.2.yaml
+++ b/content/lxc/news/lxc-1.1.2.yaml
@@ -3,7 +3,7 @@ date: 2015/04/10 00:00
 content: |-
   This is the second bugfix release for LXC 1.1.
   
-  ### Changes
+  # Changes
   
    * core: Fix non-tty stdin during attach
    * core: Improved container logging
@@ -19,7 +19,7 @@ content: |-
   
   Those stable fixes were brought to you by 9 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.2.
   

--- a/content/lxc/news/lxc-1.1.3.yaml
+++ b/content/lxc/news/lxc-1.1.3.yaml
@@ -3,7 +3,7 @@ date: 2015/08/14 00:00
 content: |-
   This is the third bugfix release for LXC 1.1.
   
-  ### Changes
+  # Changes
   
   Important:
   
@@ -69,7 +69,7 @@ content: |-
   
   Those stable fixes were brought to you by 31 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.3.
   

--- a/content/lxc/news/lxc-1.1.4.yaml
+++ b/content/lxc/news/lxc-1.1.4.yaml
@@ -72,7 +72,7 @@ content: |-
   
   Those stable fixes were brought to you by 14 individual contributors.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.4.
   

--- a/content/lxc/news/lxc-1.1.5.yaml
+++ b/content/lxc/news/lxc-1.1.5.yaml
@@ -29,7 +29,7 @@ content: |-
    * ubuntu-cloud: Use tar.xz tarballs by default (as tar.gz will soon be discontinued)
    * ubuntu-cloud: Always exit 1 on error
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 1.1.5.
   

--- a/content/lxc/news/lxc-2.0.0.yaml
+++ b/content/lxc/news/lxc-2.0.0.yaml
@@ -3,7 +3,7 @@ date: 2016/04/06 00:00
 content: |-
   The LXC team is very pleased to announce the release of LXC 2.0!
   
-  ### Highlights
+  # Highlights
   
    * All main LXC commands have now been rewritten in C
       * lxc-ls
@@ -19,7 +19,7 @@ content: |-
   
   This release was made possible by contributions (720 commits) from a total of 96 contributors.
   
-  ### New configuration options
+  # New configuration options
   
    * lxc.ephemeral: Controls whether the container is ephemeral and so will be destroyed on shutdown
    * lxc.rebootsignal: Allows to override the signal sent for container reboot
@@ -29,7 +29,7 @@ content: |-
    * lxc.init\_gid: Used by lxc-execute to set an alternative group
    * lxc.monitor.unshare: Allows unsharing the mount namespace prior to running any hook
   
-  ### New features
+  # New features
   
    * API:
       * API version is 1.2, fully backward compatible with 1.1 and 1.0
@@ -81,7 +81,7 @@ content: |-
       * ubuntu: New -v option allowing the user to set the debootstrap variant
       * ubuntu-cloud: Support for vendor-data passthrough
   
-  ### Change in behavior
+  # Change in behavior
   
    * The lxc-autostart container startup order is now reversed (to be correct)
    * The new cgfsng cgroup backend is now the recommended backend
@@ -91,18 +91,18 @@ content: |-
   We don't consider our command line tools as stable ABI so you may need to test and adapt your scripts,
   or better, port them to use our stable C API or one of its bindings.
   
-  ### Deprecation warnings
+  # Deprecation warnings
   
   The "lxc-clone" and "lxc-start-ephemeral" commands are now considered deprecated and to be replaced by the new lxc-copy.
   Those commands can still be built by using the --enable-legacy flag, however note that they will print a warning when used
   and that they will be removed from upcoming LXC releases.
   
-  ### Support
+  # Support
   This is the second LXC Long Term Support release which we will be supporting until the 1st of June 2021.
   LXC 1.0, our previous Long Term Support release, is still supported until the 1st of June 2019.
   And lastly, the previous stable release, LXC 1.1 will go end of life on the 1st of September 2016.
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.0.
   

--- a/content/lxc/news/lxc-2.0.1.yaml
+++ b/content/lxc/news/lxc-2.0.1.yaml
@@ -41,7 +41,7 @@ content: |-
    * templates: tweak Alpine DHCP configuration to send its hostname
    * templates: tweak to network configuration of the Oracle template
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.1.
   

--- a/content/lxc/news/lxc-2.0.11.yaml
+++ b/content/lxc/news/lxc-2.0.11.yaml
@@ -8,15 +8,15 @@ content: |-
 
   The changelog below is for everything which happened between 2.0.9 and 2.0.11.
 
-  ### Security fixes
-  #### Fixes CVE-2018-6556
+  # Security fixes
+  ## Fixes CVE-2018-6556
   `lxc-user-nic` when asked to delete a network interface would unconditionally open a user provided path. This code path could be used by an unprivileged user to check for the existence of a path which they wouldn't otherwise be able to reach. It may also be used to trigger side effects by causing a (read-only) open of special kernel files (ptmx, proc, sys). For more details see [here](https://nvd.nist.gov/vuln/detail/CVE-2018-6556).
 
-  #### Fixes CVE-2019-5736
+  ## Fixes CVE-2019-5736
   This release fixes [CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736). It is a major security issue afflicting all container runtimes and is exploitable when attaching to privileged containers. More details on the the bug and how it is fixed can be found [here](https://brauner.github.io/2019/02/12/privileged-containers.html).
 
-  ### Main bugfixes
-  #### Allow attaching to undefined containers
+  # Main bugfixes
+  ## Allow attaching to undefined containers
   For example the following sequence is now expected to work:
 
       lxc-start -n <container-name> -f /path/to/conf \
@@ -25,43 +25,43 @@ content: |-
       -s 'lxc.rootfs = /path/to/rootfs' \
       -s 'lxc.init_cmd = /path/to/initcmd'
 
-  #### Correctly handle namespace inheritance in attach
+  ## Correctly handle namespace inheritance in attach
   `lxc_attach` will now correctly distinguish between a caller specifying specific namespaces to attach to and a caller not requesting specific namespaces. The latter is taken by `lxc_attach` to mean that all namespaces will be attached. This also needs to include all inherited namespaces.
 
-  #### Allow the creation of `testing` and `unstable` Debian containers
+  ## Allow the creation of `testing` and `unstable` Debian containers
   Being able to create `testing` containers, regardless of what's the name of the next stable, is useful in several contexts, included but not limited to testing purposes. i.e. one won't need to explicitly switch to `bullseye` once `buster` is released to be able to continue tracking `testing`. While we are at it, let's also enable `unstable`, which is exactly the same as `sid`, but there is no reason for not being able to.
 
-  #### Enable container without `CAP_SYS_ADMIN` (cgroup handling)
+  ## Enable container without `CAP_SYS_ADMIN` (cgroup handling)
   In case cgroup namespaces are supported but we do not have `CAP_SYS_ADMIN` we need to mount cgroups for the container. This patch enables both privileged and unprivileged containers without `CAP_SYS_ADMIN`.
 
-  #### Improved `cgroup2` handling
+  ## Improved `cgroup2` handling
   Since cgroup2 is becoming more common LXC 2.0.11 comes with a wide range of improvements in that area.
 
-  #### Support read-only mounts of cgroups
+  ## Support read-only mounts of cgroups
   This is especially useful if the container lacks `CAP_SYS_ADMIN` and thus cannot remount.
 
-  #### Allow to exit from console via `SIGTERM`
+  ## Allow to exit from console via `SIGTERM`
   This allows cleanly exiting a console session without control sequences. Instead `SIGTERM` can be sent to the affected process and it will cause LXC to cleanly terminate the console session.
 
-  #### Correctly calculate the number of arguments passed when running application containers
+  ## Correctly calculate the number of arguments passed when running application containers
   The number of arguments passed to `exec` was miscalculated under certain conditions. This release ensure that the correct number of arguments is calculated and passed to `exec.`
 
-  #### Remove all unneeded locking from the codebase
+  ## Remove all unneeded locking from the codebase
   Older version of LXC used mutexes in various places to ensure thread-safety. Careful redesign of these codepaths has enabled us to remove all mutextes from the codebase. This has led to simplifications and speedups for various operations such as container start and stop.
 
-  #### Fix cgroup namespace preservation
+  ## Fix cgroup namespace preservation
   This eliminates a race and makes sure that the cached file descriptor refers to the container's cgroup namespace and not to the hosts'.
 
-  #### Allow application to share the hosts' pid namespace
+  ## Allow application to share the hosts' pid namespace
   Prior versions of LXC did not allow to share the hosts' pid namespace. Starting with this bugfix release it is possible to do this correctly.
 
-  #### Correctly handle very short-lived application containers
+  ## Correctly handle very short-lived application containers
   Prior versions had trouble to correctly handle extremely short-lived application containers. For example, LXC could incorrectly report that a container is still running when it had already shut down due to a TOCTU and refuse to restart it. This caused unnecessary delay. Also, output of such short-lived containers written to stdout could get lost or truncated. This release fixes both issues.
 
-  #### Correctly handle containers where `/proc` has been mount with `hidepid=1` or `hidepid=2`
+  ## Correctly handle containers where `/proc` has been mount with `hidepid=1` or `hidepid=2`
   In prior versions attaching to unprivileged containers as an unprivileged user with `/proc` mounted with `hidepid=1` or `hidepid=2` would fail since LXC could not retrieve needed information from `/proc`. This is now fixed.
 
-  #### Allow to force mount cgroups even when cgroup namespaces are supported
+  ## Allow to force mount cgroups even when cgroup namespaces are supported
   This lets users specify `lxc.mount.auto = cgroup:mixed:force` or `lxc.mount.auto = cgroup:ro:force` or `lxc.mount.auto = cgroup:rw:force`.
 
   When cgroup namespaces are supported LXC will not mount cgroups for the container since it assumes that the init system will mount cgroups itself if it wants to. This assumption already broke when users wanted to run containers without CAP_SYS_ADMIN.
@@ -77,7 +77,7 @@ content: |-
     - read-only cgroups:
       It is useful to be able to mount cgroups read-only to e.g. prevent changing cgroup limits from inside the container while at the same time allowing the applications to perform introspection on their own cgroups. This again is mostly useful for application containers. System containers running systemd will usually not work correctly when cgroups are mounted read-only.
 
-  #### Everything else
+  ## Everything else
   2.0.11 includes almost a year and a half of bugfixes cherry-picked from current LXC, the entire list can be found below.
 
   [details="Full changelog"]
@@ -712,7 +712,7 @@ content: |-
   [/details]
 
 
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](https://linuxcontainers.org/lxc/downloads/) and we expect most distributions will very soon ship a packaged version of LXC 2.0.11.
 
   Should you be interested in individual changes or just looking at the detailed development history, our stable branch is on [Github](https://github.com/lxc/lxc/tree/stable-2.0).

--- a/content/lxc/news/lxc-2.0.2.yaml
+++ b/content/lxc/news/lxc-2.0.2.yaml
@@ -25,7 +25,7 @@ content: |-
    * travis: test VPATH builds
    * upstart: Force lxc-instance to behave like a good Upstart client
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.2.
   

--- a/content/lxc/news/lxc-2.0.3.yaml
+++ b/content/lxc/news/lxc-2.0.3.yaml
@@ -10,7 +10,7 @@ content: |-
   
    * apparmor: Refresh generated file
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.3.
   

--- a/content/lxc/news/lxc-2.0.4.yaml
+++ b/content/lxc/news/lxc-2.0.4.yaml
@@ -43,7 +43,7 @@ content: |-
    * tests: Add unit tests for lxc\_string\_in\_array()
    * tests: Add unit tests for lxc\_string\_replace()
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.4.
   

--- a/content/lxc/news/lxc-2.0.5.yaml
+++ b/content/lxc/news/lxc-2.0.5.yaml
@@ -69,7 +69,7 @@ content: |-
    * Define LXC\_DEVEL to detect development releases
    * tools: lxc-checkconfig conditionalize devpts check
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.5.
   

--- a/content/lxc/news/lxc-2.0.6.yaml
+++ b/content/lxc/news/lxc-2.0.6.yaml
@@ -116,7 +116,7 @@ content: |-
    * tests: remove overflow tests
    * attach: do not send procfd to attached process
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.6.
   

--- a/content/lxc/news/lxc-2.0.7.yaml
+++ b/content/lxc/news/lxc-2.0.7.yaml
@@ -62,7 +62,7 @@ content: |-
    * utils: Add macro \_\_LXC\_NUMSTRLEN
    * utils: Add uid, gid, group convenience wrappers
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.7.
   

--- a/content/lxc/news/lxc-2.0.8.yaml
+++ b/content/lxc/news/lxc-2.0.8.yaml
@@ -112,7 +112,7 @@ content: |-
    * Merge `ubuntu` and `debian`case
    * start: add crucial details about lxc\_spawn()
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.8.
   

--- a/content/lxc/news/lxc-2.0.9.yaml
+++ b/content/lxc/news/lxc-2.0.9.yaml
@@ -277,7 +277,7 @@ content: |-
    * utils: Use 1LU otherwise we overflow
    * utils: Use access instead of stat
   
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](/lxc/downloads/) and we expect most distributions
   will very soon ship a packaged version of LXC 2.0.9.
   

--- a/content/lxc/news/lxc-2.1.1.yaml
+++ b/content/lxc/news/lxc-2.1.1.yaml
@@ -67,7 +67,7 @@ content: |-
    * utils: Fix lxc\_popen()/lxc\_pclose()
    * utils: Remove dead assignments in lxc\_popen()
 
-  ### Downloads
+  # Downloads
   The release tarballs may be found on our [download page](https://linuxcontainers.org/lxc/downloads/) and we expect most distributions  
   will very soon ship a packaged version of LXC 2.1.1.
 

--- a/content/lxc/news/lxc-2.1.yaml
+++ b/content/lxc/news/lxc-2.1.yaml
@@ -7,8 +7,8 @@ content: |-
   Note that this isn't a LTS release and we'll therefore only be supporting LXC 2.1 for a year.
   Production environments that require longer term support should remain on LXC 2.0 which is supported until June 2021.
   
-  ## New features
-  ### Resource limit support
+  # New features
+  ## Resource limit support
   Similar to requesting specific cgroup limits users can specify any limits for any resource
   the underlying kernel is aware of by prefixing the name of the limit with "lxc.prlimit."
   in the container's configuration file. For example, to request a limit on the number of processes
@@ -17,7 +17,7 @@ content: |-
       lxc.prlimit.nproc = unlimited
       lxc.prlimit.nice = 4
   
-  ### Support for unprivileged openvswitch networks
+  ## Support for unprivileged openvswitch networks
   It is now possible to define openvswitch networks as an unprivileged user:
   
       lxc.net.0.type = veth
@@ -28,7 +28,7 @@ content: |-
   LXC 2.1. will take care to properly delete the host-side veth device from the
   openvswitch database on shutdown.
   
-  ### New `lxc.cgroup.dir` key
+  ## New `lxc.cgroup.dir` key
   The `lxc.cgroup.dir` key lets users specify the name of the parent cgroup under
   which the container's cgroup will be created. Setting `lxc.cgroup.dir` will
   override the system-wide setting for `lxc.cgroup.pattern`.
@@ -36,7 +36,7 @@ content: |-
   For example, setting `lxc.cgroup.dir = mycontainers` for a container with `lxc.uts.name = c1`
   will cause LXC to create the cgroups `mycontainers/c1` for all controllers in the cgroup hierarchy.
   
-  ### Support for hybrid cgroup layout
+  ## Support for hybrid cgroup layout
   Since the advent of cgroup v2 some init systems have decided to allow for a hybrid mode in which
   cgroup v1 per-controller hierarchies can be used simultaneously with an empty cgroup v2 hierarchy.
   Systems that use this hybrid mode usually have a cgroup layout similar to this one:
@@ -50,17 +50,17 @@ content: |-
   This can be confirmed by testing whether `findmnt | grep cgroup2` returns a matching line.
   LXC 2.1 supports this hybrid mode.
   
-  ### Limiting the number of ptys a container can allocate
+  ## Limiting the number of ptys a container can allocate
   Setting `lxc.pty.max` will cause LXC to mount the container's devpts with the requested limit
   on the number of usable ptys. For example, setting `lxc.pty.max = 10` will only allow
   the container to allocate `10` ptys. The default setting is `1024`.
   
-  ### `bool lxc_config_item_is_supported(const char *key)` API extension
+  ## `bool lxc_config_item_is_supported(const char *key)` API extension
   This function let's users query the liblxc whether a specific configuration item is supported for this library.
   This is particularly useful for embedded users that running versions of liblxc that come with significantly
   less configuration options than the standard liblxc library or liblxc's that have backported new configuration items.
   
-  ### New log API extension
+  ## New log API extension
   
       struct lxc_log {
           const char *name;
@@ -85,7 +85,7 @@ content: |-
   
   These types and functions let users initialize LXC logging. This is useful for users who use the liblxc API directly.
   
-  ### Deprecation of `lxc-monitord`
+  ## Deprecation of `lxc-monitord`
   Starting with LXC 2.1 the `lxc-monitord` binary is marked as deprecated.
   It is not required anymore to start daemonized containers. Instead, LXC 2.1 switches to an implementation using
   an abstract unix domain socketpair. This has the advantage of spawning one less processes on container startup which is
@@ -93,7 +93,7 @@ content: |-
   
   Also, testing the new implementation on heavy workloads has shown this solution to be more robust and reliable in every way.
   
-  ### `lxc-copy` create snapshots on `tmpfs`
+  ## `lxc-copy` create snapshots on `tmpfs`
   Place an ephemeral container started with -e flag on a tmpfs.
   Restrictions are that you cannot request the data to be kept while placing the container on a tmpfs,
   that either overlay or aufs backing storage must be used, and that the storage backend of the original
@@ -123,11 +123,11 @@ content: |-
   This should be all that is required to restore the exact behaviour we would get with a normal clone.
   NOTE: If the container is rebooted all changes made to it are lost. This is not easy to prevent since each reboot remounts the rootfs again.
   
-  ## Configuration changes
+  # Configuration changes
   A lot of configuration keys have been renamed to make the experience of configuring a container much more consistent.
   LXC 2.1 ensures that all keys that have subkeys are properly namespaces via the "." syntax.
   
-  ### Network configuration
+  ## Network configuration
   The network configuration keys have all been given a new prefix. Some of them  have also been renamed.
   From LXC 2.1. onwards network configuration keys using the "lxc.network" prefix are considered deprecated.
   They are replaced by network configuration keys using the new "lxc.net" prefix.
@@ -180,7 +180,7 @@ content: |-
   
   would lead to LXC associating the network with `virbr0` since it is the last key in the configuration.
   
-  ### Table of changed configuration keys
+  ## Table of changed configuration keys
   The following table lists the legacy configuration keys on the left side and their corresponding new keys on the right side. Keys that have been entirely removed will have "-" as entry in the "New Key" column and a comment saying "removed" in the "Comments" table.
   
       Legacy Key                           | New Key                       | Comments
@@ -227,7 +227,7 @@ content: |-
       lxc.tty                              | lxc.tty.max                   |
       lxc.utsname                          | lxc.uts.name                  |
   
-  ### `lxc-update-config` script
+  ## `lxc-update-config` script
   LXC 2.1 comes with a new script `lxc-update-config` which can be used to upgrade existing legacy
   LXC configurations to valid LXC 2.1 configurations by simply passing
   
@@ -238,7 +238,7 @@ content: |-
   The backup is made in case the upgrade does not yield a usable LXC 2.1 config file.
   After creating the backup the script will replace all legacy configuration keys with their new counterparts.
   
-  ## Deprecation warnings
+  # Deprecation warnings
   LXC 2.1 intends to be fully backward compatible with respect to pre-2.1 configuration files.
   This specifically means that the presence of any deprecated keys should not prevent the container from being usable.
   However, LXC 2.1 will warn about the presence of any deprecated configuration keys.

--- a/content/lxc/news/lxc-3.0.0.yaml
+++ b/content/lxc/news/lxc-3.0.0.yaml
@@ -10,7 +10,7 @@ content: |-
 
   # Major changes
 
-  #### All commands support `lxc-start <container-name>` syntax
+  ## All commands support `lxc-start <container-name>` syntax
   The LXC tools now support passing the container name without the `-n` command line flag. For example, you can now run:
   ```
   chb@conventiont|~
@@ -37,20 +37,20 @@ content: |-
   ```
   [<img src='https://discuss.linuxcontainers.org/uploads/default/original/1X/7861eb06f384affb0b2c0ba419e09a2004354c40.png' alt='asciicast'>](https://asciinema.org/a/174496)
 
-  #### Removed support for all legacy configuration keys
+  ## Removed support for all legacy configuration keys
   All legacy configuration keys are unsupported from LXC 3.0 onwards.
   The full list of deprecated keys and their new counterparts can be gathered from the [LXC 2.1 release announcement](https://discuss.linuxcontainers.org/t/lxc-2-1-has-been-released/487).
 
   The `lxc-update-config` tool can be used to convert an older, now invalid, configuration to the new format.
 
-  #### Full support for the unified cgroup hierarchy including resource limits
+  ## Full support for the unified cgroup hierarchy including resource limits
   We are pleased to announce that LXC will fully support the new unified cgroup hierarchy (or cgroup v2, cgroup2). To this end we also introduced a new configuration key `lxc.cgroup2.[controller name]` to configure cgroup limits on the unified cgroup hierarchy.
   For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/19/lxc-lands-unified-cgroup-hierarchy-support.html).
 
-  #### Removal of legacy cgmanager and cgfs cgroup drivers
+  ## Removal of legacy cgmanager and cgfs cgroup drivers
   LXC removed the `cgmanager` and `cgfs` legacy cgroup drivers cleaning up a lot of code in the process. For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/20/lxc-removes-legacy-cgroup-drivers.html).
 
-  #### Splitting out templates and language bindings
+  ## Splitting out templates and language bindings
   LXC removes the legacy template-based container build system in favor of the new project [distrobuilder](https://github.com/lxc/distrobuilder). For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/27/lxc-removes-legacy-template-build-system.html).
 
   Note that to simplify migration, the old template scripts and configuration files remain available in a [separate repository](https://github.com/lxc/lxc-templates) and are released along with LXC 3.0.0 as `lxc-templates`.
@@ -86,11 +86,11 @@ content: |-
      [<img src='https://discuss.linuxcontainers.org/uploads/default/original/1X/e76c06d093d3e9079562ea15fc57656958001683.png' alt='asciicast'>](https://asciinema.org/a/165784)
 
 
-  #### Moving the cgroup PAM module into the LXC tree
+  ## Moving the cgroup PAM module into the LXC tree
   LXC has always supported fully unprivileged containers, i.e. unprivileged containers run by unprivileged users. An important piece in doing so was a PAM module that created writable cgroups for unprivileged users. This has been moved from the LXCFS tree into the LXC tree itself to make it even easier for users to run fully unprivileged containers.
   For detailed information you can read [this blogpost](https://brauner.github.io/2018/02/28/lxc-includes-cgroup-pam-module.html).
 
-  #### New `OCI` template
+  ## New `OCI` template
   This adds support for creating application containers from OCI formats. 
   Examples:
   - create a container from a local OCI layout in ../oci:
@@ -105,14 +105,14 @@ content: |-
 
   The URL is specified in the same format as for `skopeo copy`.
 
-  #### Simple and efficient ringbuffer for console logging
+  ## Simple and efficient ringbuffer for console logging
   LXC supports logging the container's console to a file. This had the unfortunate side effect of allowing a user in the container to effectively write as much data as they wanted on the host, possibly bypassing quotas in place for the container.
 
   This basic implementation was also somewhat annoying to query, having to read a potentially huge file which wasn't reset on container restart.
 
   LXC 3.0 now introduces a ringbuffer for console logging. This in-memory buffer is size-limited and can be queried through a new function in the LXC API. It can be reset at any time and can be dumped to disk on container shutdown.
 
-  #### Allow seccomp to filter syscalls based on arguments
+  ## Allow seccomp to filter syscalls based on arguments
   In order to support filtering syscalls based on arguments the `seccomp` version `2` specification is extended to the following form:
 
       syscall_name action [index,value,op,valueTwo] [index,value,op]...
@@ -153,21 +153,21 @@ content: |-
       unshare errno 9 [0,0x10000000,SCMP_CMP_EQ]
       unshare errno 2 [0,0x20000000,SCMP_CMP_EQ]
 
-  #### Support for daemonized app containers
+  ## Support for daemonized app containers
   LXC has been running application container through a minimal init system since its first release in 2008. PID namespaces expect a functional init system capable of handling signals and reaping exiting child processes. This is why application containers always run the application as the second process.
   New versions of LXC will now additionally allow you to run basically any process daemonized:
   [<img src='https://discuss.linuxcontainers.org/uploads/default/original/1X/ef61a968b654bf44f3506d8ccc95d4cd83407e46.png' alt='asciicast'>](https://asciinema.org/a/174498)
 
-  #### Remove all internal symbols from `lxc-*` tools
+  ## Remove all internal symbols from `lxc-*` tools
   The `lxc-*` tools now only entirely rely on the public LXC API.
 
-  #### Handle `/proc` being mounted with the `hidepid={1,2}` property
+  ## Handle `/proc` being mounted with the `hidepid={1,2}` property
   This enables attaching to containers when the host's `/proc` filesystem was mounted with the `hidepid={1,2}` option which restricts access to `/proc/PID` directories.
 
-  #### Support mount propagation for mounts
+  ## Support mount propagation for mounts
   This adds support for mount propagation (`private`, `shared`, `slave`, `unbindable`, `rprivate`, `rshared`, `rslave`, `runbindable`) to mount entries specified via `lxc.mount.entry` and `lxc.mount.fstab`.
 
-  #### Hardened thread-safety
+  ## Hardened thread-safety
   - removed all mutexes
   - replaced all calls to `exit()` in child processes with `_exit()`
   - replaced all `F_SETLK`, `F_SETLKW`, `F_GETLK` with  `F_OFD_SETLK`, `F_OFD_SETLKW`, `F_OFD_GETLK` open file description locks
@@ -175,70 +175,70 @@ content: |-
 
   More details can be gathered from [this blogpost](https://brauner.github.io/2018/03/04/locking-in-shared-libraries.html).
 
-  #### Remove `aufs` storage driver
+  ## Remove `aufs` storage driver
   The `aufs` storage driver has been deprecated since LXC 2.1 and is now officially removed.
 
-  #### Coding style and code cleanups
+  ## Coding style and code cleanups
   Code cleanups have been performed widely across the codebase based on our written down [coding style](https://github.com/lxc/lxc/blob/master/CODING_STYLE.md).
 
   # New Configuration Keys
 
-  #### `lxc.cgroup2.[controller name]`
+  ## `lxc.cgroup2.[controller name]`
   Specify the control group value to be set on the unified cgroup shierarchy. The controller name is the literal name of the control group. The permitted names and the syntax of their values is not dictated by LXC, instead it depends on the features of the Linux kernel running at the time  the  container is started, for example, `lxc.cgroup2.memory.high`.
 
-  #### `lxc.hook.version`
+  ## `lxc.hook.version`
   To pass the arguments in new style via environment variables set to `1` otherwise set to `0` to pass them as arguments.  This  setting  affects  all  hooks arguments  that were traditionally passed as arguments to the script. Specifically, it affects the container name, section (e.g. 'lxc', 'net') and hook type (e.g.  'clone', 'mount', 'pre-mount') arguments. If new-style hooks are used then the arguments will be available as environment  variables. The container name will be set in `LXC_NAME`. (This is set independently of the value used for this config item.) The section will be set `LXC_HOOK_SECTION` and the hook type will be set in `LXC_HOOK_TYPE`.  It also affects how the paths to file descriptors referring to the container's namespaces are  passed. If  set  to  `1`  then  for  each namespace a separate environment variable `LXC_[NAMESPACE IDENTIFIER]_NS` will be set. If set to `0` then the paths will be passed as arguments to the stop hook.
 
-  #### `lxc.execute.cmd`
+  ## `lxc.execute.cmd`
   Absolute path from container rootfs to the binary to run by default. This configuration options can be set to to specify the default binary for application container started via the `execute()` API call and accompanies the system container based `lxc.init.cmd` configuration key.
 
-  #### `lxc.init.cwd`
+  ## `lxc.init.cwd`
   Absolute path inside the container to use as the working directory.
 
-  #### `lxc.proc.[proc file name]`
+  ## `lxc.proc.[proc file name]`
   Specify the proc file name to be set. The file names available are those listed under the `/proc/PID/` directory.  For example, `lxc.proc.oom_score_adj = 10`.
 
-  #### `lxc.console.buffer.size`
+  ## `lxc.console.buffer.size`
   Setting this option instructs LXC to allocate an in-memory ringbuffer. The container's console output will be written to the ringbuffer.  Note  that ringbuffer  must be at least as big as a standard page size. When passed a value smaller than a single page size LXC will allocate a ringbuffer of a single page size. A page size is usually `4kB`.  The keyword `auto` will cause LXC to allocate a ringbuffer of `128kB`.  When manually specifying a size for  the  ringbuffer the value should be a power of `2` when converted to bytes. Valid size prefixes are `kB`, `MB`, `GB`. (Note that all conversions are based on multiples of `1024`. That means `kb == KiB`, `MB == MiB`, `GB == GiB`.)
 
-  #### `lxc.console.size`
+  ## `lxc.console.size`
   Setting this option instructs LXC to place a limit on the size of the console log file specified in `lxc.console.logfile`. Note that size of  the  log file  must  be  at  least as big as a standard page size. When passed a value smaller than a single page size LXC will set the size of log file to a single page size. A page size is usually `4kB`.  The keyword `auto` will cause LXC to place a limit of `128kB` on the log file.  When manually  specifying a size for the log file the value should be a power of `2` when converted to bytes. Valid size prefixes are `kB`, `MB`, `GB`. (Note that all conversions are based on multiples of `1024`. That means `kb == KiB`, `MB == MiB`, `GB == GiB`.)  If users want to mirror the console ringbuffer on  disk they should set `lxc.console.size` equal to `lxc.console.buffer.size`.
 
-  #### `lxc.console.rotate`
+  ## `lxc.console.rotate`
   Whether  to rotate the console logfile specified in `lxc.console.logfile`.
 
-  #### `relative` option for `lxc.mount.entry`
+  ## `relative` option for `lxc.mount.entry`
   A mountpoint specified with the `relative` property set will be taken to be relative to the mounted container root. For instance,
 
       lxc.mount.entry = /dev/null proc/kcore none bind,relative 0 0 
 
   Will expand `dev/null` to `${LXC_ROOTFS_MOUNT}/dev/null`, and mount it to `proc/kcore` inside the container.
 
-  #### `force` property for `cgroup` mounts specified via `lxc.mount.auto`
-  ##### `cgroup:mixed:force:`
+  ## `force` property for `cgroup` mounts specified via `lxc.mount.auto`
+  ### `cgroup:mixed:force:`
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup:mixed`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
 
-  ##### `cgroup:ro:force:`
+  ### `cgroup:ro:force:`
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup:ro`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
 
-  ##### `cgroup:rw:force:`
+  ### `cgroup:rw:force:`
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup:rw`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
 
-  ##### `cgroup-full:mixed:force:`
+  ### `cgroup-full:mixed:force:`
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup-full:mixed`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
 
-  ##### `cgroup-full:ro:force:`
+  ### `cgroup-full:ro:force:`
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup-full:ro`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
 
-  ##### `cgroup-full:rw:force:`
+  ### `cgroup-full:rw:force:`
   The force option will cause LXC to perform the cgroup mounts for the container under all circumstances.  Otherwise it is similar to `cgroup-full:rw`.  This is mainly useful when the cgroup namespaces are enabled where LXC will normally leave mounting cgroups to the init binary of the container since it is perfectly safe to do so.
 
-  #### `lxc.namespace.clone`
+  ## `lxc.namespace.clone`
   Specify namespaces which the container is supposed to be created with. The namespaces to create are specified as a space separated list. Each namespace must correspond to one of the standard namespace identifiers as seen in the `/proc/PID/ns` directory. When `lxc.namespace.clone` is not explicitly set all namespaces supported by the kernel and the current configuration will be used.
 
   To create a new `mount`, `net` and `ipc` namespace set `lxc.namespace.clone = mount net ipc`.
 
-  #### `lxc.namespace.keep`
+  ## `lxc.namespace.keep`
   Specify  namespaces  which the container is supposed to inherit from the process that created it. The namespaces to keep are specified as a space separated list. Each namespace must correspond to one of the standard namespace identifiers as seen in the `/proc/PID/ns` directory.  The  lxc.namespace.keep is a blacklist option, i.e. it is useful when enforcing that containers must keep a specific set of namespaces.
 
   To keep the `network`, `user` and `ipc` namespace set `lxc.namespace.keep = user net ipc`.
@@ -247,7 +247,7 @@ content: |-
 
   Note  that  if the container requests a new user namespace and the container wants to inherit the network namespace it needs to inherit the user namespace as well.
 
-  #### `lxc.namespace.share.[namespace identifier]`
+  ## `lxc.namespace.share.[namespace identifier]`
   Specify a namespace to inherit from another container or process.  The `[namespace identifier]` suffix needs to be replaced with one  of  the  namespaces that appear in the `/proc/PID/ns` directory.
 
   To  inherit  the  namespace  from  another  process  set  the  `lxc.namespace.share.[namespace identifier]`  to  the PID of the process, e.g. `lxc.namespace.share.net = 42`.
@@ -262,10 +262,10 @@ content: |-
 
   Note that if two processes are in different user namespaces and one process wants to inherit the other's network namespace it usually needs to  inherit the user namespace as well.
 
-  #### `lxc.sysctl.[kernel parameters name]`
+  ## `lxc.sysctl.[kernel parameters name]`
   Specify the kernel parameters to be set. The parameters available are those listed under `/proc/sys/`. Note that not all sysctls are namespaced. Changing Non-namespaced sysctls will cause the system-wide setting to be modified.  `sysctl(8)`. If used with no value, LXC will clear the parameters  specified up to this point.
 
-  #### `lxc.hook.start-host`
+  ## `lxc.hook.start-host`
   A hook to be run in the host's namespace after the container has been setup, and immediately before starting the container init.
 
   This should satisfy several use cases.  One example is support for CNI.
@@ -288,9 +288,9 @@ content: |-
   The nic 'peer1' was placed into the container as expected.
   For this to work, we pass the container init's pid as LXC_PID in an environment variable, since lxc-info cannot work at that point.
 
-  #### API extensions
+  ## API extensions
 
-  ##### `console_log()`
+  ### `console_log()`
   A new API extension
 
       	int console_log(struct lxc_container *c, struct lxc_console_log *log);
@@ -321,10 +321,10 @@ content: |-
   };
   ```
 
-  ##### `reboot2()`
+  ### `reboot2()`
   This adds `reboot2()` as a new API extension. This function properly wait until a reboot succeeded. It takes a timeout argument. When set to `> 0` `reboot2()` will block until the timeout is reached, if timeout is set to zero `reboot2()` will not block, if set to `-1` `reboot2()` will block indefinitely.
 
-  ##### `MIGRATE_FEATURE_CHECK` for `CRIU` ``migrate()` API call
+  ### `MIGRATE_FEATURE_CHECK` for `CRIU` ``migrate()` API call
   For migration optimization features like pre-copy or post-copy migration the support cannot be determined by simply looking at the `CRIU` version.  Features like that depend on the architecture/kernel/criu combination and `CRIU` offers a feature checking interface to query if it is supported.
 
   This adds a LXC interface to query CRIU for those feature via the `migrate()` API call. For the recent pre-copy migration support in LXD this can be used to automatically detect if pre-copy migration should be used.
@@ -335,7 +335,7 @@ content: |-
 
   Currently only querying the features `FEATURE_MEM_TRACK` and `FEATURE_LAZY_PAGES` are supported.
 
-  ##### add `LXC_ATTACH_TERMINAL` to `attach()` API call
+  ### add `LXC_ATTACH_TERMINAL` to `attach()` API call
   Allocation of a new terminal has been moved into the API itself. Callers can  now set `LXC_ATTACH_TERMINAL` to request to be attached to a new terminal allocated from the host's `devpts` mount before attaching to the container.
 
   # Support and upgrade

--- a/content/lxc/news/lxc-3.0.2.yaml
+++ b/content/lxc/news/lxc-3.0.2.yaml
@@ -2,12 +2,12 @@ title: LXC 3.0.2 has been released
 date: 2018/08/21 15:08
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-2-has-been-released/2504
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 3.0.2!
 
   As a stable bugfix release, no major changes have been done, instead focusing on bugfixes and minor usability improvements.
 
-  #### Highlights
+  ## Highlights
 
   - Adapt to changes in Linux `4.18` which allows to create but not to open devices nodes in user namespaces
   - Allocate network namespace id on container startup
@@ -19,7 +19,7 @@ content: |-
     This significantly reduced the size of the codebase.
   - Tree-wide coding style fixes
 
-  ##### CVE-2018-6556
+  ### CVE-2018-6556
 
   This release fixes [CVE-2018-6556](http://seclists.org/oss-sec/2018/q3/81) via commit [CVE 2018-6556: verify netns fd in lxc-user-nic](https://github.com/lxc/lxc/commit/c1cf54ebf251fdbad1e971679614e81649f1c032): `lxc-user-nic` when asked to delete a network interface will unconditionally open a user provided path. 
 
@@ -27,7 +27,7 @@ content: |-
 
   Affected releases are LXC: 2.0 versions above and including 2.0.9; 3.0 versions above and including 3.0.0, prior to 3.0.2.
 
-  #### Bugfixes (LXC)
+  ## Bugfixes (LXC)
 
   - fixed a range of bugs found by Coverity
   - lxc-usernsexec: cleanup and bugfixes
@@ -78,7 +78,7 @@ content: |-
   - conf: only use newuidmap and newgidmap when necessary
   - autotools: support tls in cross-compile
 
-  #### Bugfixes (LXC templates)
+  ## Bugfixes (LXC templates)
 
    - fedora: support Fedora 28
    - templates: opensuse: Add support for openSUSE Leap 15
@@ -86,14 +86,14 @@ content: |-
    - templates: lxc-opensuse.in: Ensure cache is fully populated
    - templates: lxc-opensuse.in: Fix openSUSE Leap 15 cache url
 
-  #### Bugfixes (python3 binding)
+  ## Bugfixes (python3 binding)
 
    - Fix typo in README.md
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 3.0.2 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxc-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.2.tar.gz) (GPG: [lxc-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.2.tar.gz.asc))
    - LXC templates tarball: [lxc-templates-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.2.tar.gz) (GPG: [lxc-templates-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.2.tar.gz.asc))
    - LXC python3 bindings tarball: [python3-lxc-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.2.tar.gz) (GPG: [python3-lxc-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.2.tar.gz.asc))

--- a/content/lxc/news/lxc-3.0.3.yaml
+++ b/content/lxc/news/lxc-3.0.3.yaml
@@ -2,19 +2,19 @@ title: LXC 3.0.3 has been released
 date: 2018/11/23 01:11
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-3-has-been-released/3358
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 3.0.3!
 
   As a stable bugfix release, no major changes have been done, instead focusing on bugfixes and minor usability improvements.
 
-  #### Highlights
+  ## Highlights
 
    - Improved our default build flags to make use of compiler hardening
    - Added support for netlink strict property checking on newer kernels
    - Added support for new netlink interface/address netns API 
    - Added handling of the kernel keyring on startup
 
-  #### Bugfixes (LXC)
+  ## Bugfixes (LXC)
 
    - CONTRIBUTING: Update reference to kernel coding style
    - CONTRIBUTING: Link to latest online kernel docs
@@ -388,20 +388,20 @@ content: |-
    - cgfsng: remove freezer requirement
    - start: don't call cgroup_exit() twice
 
-  #### Bugfixes (LXC templates)
+  ## Bugfixes (LXC templates)
 
    - alpine: Make dropping setpcap optional
    - plamo: Update the default version to 7.x
    - sabayon: Don't fail on existing directories
 
-  #### Bugfixes (python3 binding)
+  ## Bugfixes (python3 binding)
 
    - No changes in this release, version bump only
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 3.0.3 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxc-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.3.tar.gz) (GPG: [lxc-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.3.tar.gz.asc))
    - LXC templates tarball: [lxc-templates-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.3.tar.gz) (GPG: [lxc-templates-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.3.tar.gz.asc))
    - LXC python3 bindings tarball: [python3-lxc-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.3.tar.gz) (GPG: [python3-lxc-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.3.tar.gz.asc))

--- a/content/lxc/news/lxc-3.0.4.yaml
+++ b/content/lxc/news/lxc-3.0.4.yaml
@@ -2,23 +2,23 @@ title: LXC 3.0.4 has been released
 date: 2019/06/21 22:06
 origin: https://discuss.linuxcontainers.org/t/lxc-3-0-4-has-been-released/5080
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 3.0.4!
 
   As a stable bugfix release, no major changes have been done, instead focusing on bugfixes and minor usability improvements.
 
-  #### Highlights
-  ##### [Fix for runC CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
+  ## Highlights
+  ### [Fix for runC CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
   This release comes with  a fix for the privileged container breakout discovered earlier this year. As per our policy we don't consider privileged containers root safe and thus LXC as not received a CVE for this. However, we still provide a fix in this release. For more details see [this blog post](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container).
 
-  ##### Prefix veth interface names with caller's uid
+  ### Prefix veth interface names with caller's uid
   To make it easier for users to inspect veth devices LXC will now prefix the uid of the caller for the host veth device.
 
-  ##### Improve using LXC on Android devices
+  ### Improve using LXC on Android devices
   This makes LXC look for standard tools in locations such as `/system/bin` that are specific to Android.
   Additionally, it is now possible to correctly allocate loop devices on Android.
 
-  ##### Backport all compiler hardening options which are standard on current master.
+  ### Backport all compiler hardening options which are standard on current master.
   This backports:
 
       -fdiagnostics-color
@@ -55,37 +55,37 @@ content: |-
       -z relro
       -z now
 
-  ##### Remove all stack allocation (`alloca()`)
+  ### Remove all stack allocation (`alloca()`)
   As is already the case on master, all stack allocations via `alloca()` have been wiped from the codebase to increase security.
 
-  ##### Added support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/)
+  ### Added support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/)
   This adds support for the [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/) code quality checker.
 
-  ##### Add support for [coccinelle](https://github.com/coccinelle/coccinelle) code transformation tool
+  ### Add support for [coccinelle](https://github.com/coccinelle/coccinelle) code transformation tool
   This allows us to automatically detect, remove, or add code to the LXC codebase to improve security and reliability.
 
-  ##### Compiler based resource cleanup
+  ### Compiler based resource cleanup
   The codebase will be slowly switched over to make user of cleanup attributes supported by compilers such as `gcc` and `clang`.
 
-  ##### Remove `fgets()` from the codebase
+  ### Remove `fgets()` from the codebase
   To improve security all uses of `fgets()` have been removed from the codebase. Use of this function in new code is strongly discouraged.
 
-  ##### Improve `cgroup2` handling
+  ### Improve `cgroup2` handling
   With this release `cgroup2` layouts will be better supported.
 
-  ##### Setup `lxc.mount.entry` right after `lxc.mount.fstab`
+  ### Setup `lxc.mount.entry` right after `lxc.mount.fstab`
   This allows us to unify the mounting logic in LXC.
 
-  ##### Expand namespace sharing options
+  ### Expand namespace sharing options
   When inheriting a namespace a pathname to a namespace file descriptor can now be specified.
 
-  ##### Expand close-on-exec usage
+  ### Expand close-on-exec usage
   All file descriptors that can be made close-on-exec are now close-on-exec.
 
-  ##### Support `pidfd` api
+  ### Support `pidfd` api
   Newer kernel versions allow interaction with processes through process file descriptors (`pidfd`s). This eliminates various race conditions when e.g. sending signals or retrieving process information. This LXC version make use of the `pidfd_send_signal()` syscall and the `CLONE_PIDFD` flag with the `clone()` syscall.
 
-  #### Bugfixes (LXC)
+  ## Bugfixes (LXC)
 
   - Fix cgroup deletion by not prematurely freeing the path to delete
   - Fix `lxc-usernsexec` when falling back to the default id mapping
@@ -393,20 +393,20 @@ content: |-
   [/details]
 
 
-  #### Bugfixes (LXC templates)
+  ## Bugfixes (LXC templates)
 
    - Add new dependency for wget for lxc-slackware template
    - plamo: Workaround for building plamo 32bit 6.x container on current 7.x
    - plamo: Support https as download scheme and default to https
 
-  #### Bugfixes (python3 binding)
+  ## Bugfixes (python3 binding)
 
    - No changes in this release, version bump only
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 3.0.4 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxc-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.0.4.tar.gz) (GPG: [lxc-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.0.4.tar.gz.asc))
    - LXC templates tarball: [lxc-templates-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.4.tar.gz) (GPG: [lxc-templates-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-templates-3.0.4.tar.gz.asc))
    - LXC python3 bindings tarball: [python3-lxc-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.4.tar.gz) (GPG: [python3-lxc-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/python3-lxc-3.0.4.tar.gz.asc))

--- a/content/lxc/news/lxc-3.1.yaml
+++ b/content/lxc/news/lxc-3.1.yaml
@@ -2,45 +2,45 @@ title: LXC 3.1 has been released
 date: 2018/12/14 04:12
 origin: https://discuss.linuxcontainers.org/t/lxc-3-1-has-been-released/3527
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 3.1.0!
 
   This is an intermediary feature release and not one of our major LTS releases or LTS bugfix releases. We plan on doing more of those in the future, but note that support on those releases will be limited as we mostly focus on LTS for production environments.
 
-  ### New features
-  #### enable various remount options with AppArmor
+  # New features
+  ## enable various remount options with AppArmor
   Read-write bind mounts need to be restricted for some paths in order to avoid MAC restriction bypasses, but read-only bind mounts shouldn't have that problem. Additionally, combinations of `nosuid`, `nodev` and `noexec` flags shouldn't be a problem either and are required with newer systemd versions, so let's allow those as long as they're combined with `ro,remount,bind`.
 
-  #### support `NETLINK_DUMP_STRICT_CHK`
+  ## support `NETLINK_DUMP_STRICT_CHK`
   Make use of the new socket option, `NETLINK_DUMP_STRICT_CHK`, that userspace can use via `setsockopt()` to request strict checking of headers and attributes on dump requests.
 
   To get dump features such as kernel side filtering based on data in the header or attributes appended to the dump request, userspace must call `setsockopt()` for `NETLINK_DUMP_STRICT_CHK` and a non-zero value. This is necessary to make use of the `IFA_TARGET_NETNSID` property used to efficiently retrieve information from network namespaces by LXC.
 
-  #### allocate new keyring on startup
+  ## allocate new keyring on startup
   To isolate and protect the hosts keyring each LXC container will try to allocate a new keyring for itself on startup.
 
-  #### full `cgroup2` support
+  ## full `cgroup2` support
   LXC has supported `cgroup2` for a while now without adhering to its strict delegation model. Now, LXC is ready to fully support it.
 
-  #### implement efficient way to retrieve network devices and addresses from containers
+  ## implement efficient way to retrieve network devices and addresses from containers
   Based on kernel work done by the LXD team it is now possible to query a network namespace without having to perform costly `fork()` and `setns()` syscalls. Instead, the network namespace is identified by a network namespace identifier. As such a new network namespace aware version and very improved and safe version of `getifaddrs()` named `netns_getifaddrs()` is introduced that LXC uses. It is a strict superset of `getifaddrs()`.
 
-  #### introduce `lxc_has_api_extension()` into the API
+  ## introduce `lxc_has_api_extension()` into the API
   Going forward each new API addition will be given a unique name that can be passed to `lxc_has_api_extension()`. This is modeled after LXD's API extension checks. This allows API users to query the given LXC instance whether a given API extension is supported.
 
-  #### add `lxc.cgroup.relative` configuration key
+  ## add `lxc.cgroup.relative` configuration key
   This adds the new `lxc.cgroup.relative` config key. The key can be used to instruct LXC to never escape to the root cgroup. This makes it easy for users to adhere to restrictions enforced by `cgroup2` and `systemd`. Specifically, this makes it possible to run LXC containers as systemd services.
 
-  #### allocate new network namespace identifier on startup
+  ## allocate new network namespace identifier on startup
   Each container will now have a unique network namespace identifier assigned on startup. This can be used by LXC to siginficantly speed up operations performed on network namespaces (e.g. network device configuration and retrieval).
 
-  #### add `lxc.rootfs.managed` configuration key
+  ## add `lxc.rootfs.managed` configuration key
   This introduces a new config key which can be used to indicate whether this LXC instance is managing the container storage. If LXC is not managing the storage then LXC will not modify the container storage. For example, an API call to `c->destroy(c)` will then run any destroy hooks but will not destroy the actual rootfs (Unless, of course, the hook does so behind LXC's back.).
 
-  #### removal of all `VLA`s
+  ## removal of all `VLA`s
   LXC is now compiled with `-Wvla` by default.
 
-  #### AppArmor profile generation
+  ## AppArmor profile generation
   This copies lxd's AppArmor profile generation. This tries to detect features such as cgroup namespaces, AppArmor namespaces and stacking support, and has profile parts conditionally for unprivileged containers.
 
   This introduces the following changes to the configuration:
@@ -55,7 +55,7 @@ content: |-
   `--with-apparmor-cache-dir` `./configure` option.
 
 
-  #### add mount injection api
+  ## add mount injection api
   This work has been done as part of the bachelor thesis of [LizaTretyakova](https://github.com/LizaTretyakova). The team is very happy and thankful for this outstanding work!
 
   Being able to dynamically interact with mounts while a container is running has been a long-standing request from users and something we have supported in LXD for a long time now. This feature enables the following main use-cases:
@@ -73,13 +73,13 @@ content: |-
       int (*umount)(struct lxc_container *c, const char *target, unsigned long mountflags,
                             struct lxc_mount *mnt);
 
-  #### add `lxc.monitor.signal.pdeath` configuration key
+  ## add `lxc.monitor.signal.pdeath` configuration key
   Set the signal to be sent to the container's init when the lxc monitor exits. By default it is set to `SIGKILL` which will cause all container processes to be killed when the lxc monitor process dies. To ensure that containers stay alive even if lxc monitor dies set this to `0`.
 
-  #### build a shared and static `liblxc` library
+  ## build a shared and static `liblxc` library
   LXC will now by default build both a shared and a static library.
 
-  #### adapt to `mknod()` changes in Linux Kernel 4.18
+  ## adapt to `mknod()` changes in Linux Kernel 4.18
   Starting with commit
 
       55956b59df33 ("vfs: Allow userns root to call mknod on owned filesystems.")
@@ -108,27 +108,27 @@ content: |-
 
   which will cause an `EPERM` because the device node is located on an fs owned by non-init-userns and thus doesn't grant access to device nodes due to `SB_I_NODEV`. LXC has learned to correctly handle this case.
 
-  #### use `execveat()` to execute application containers
+  ## use `execveat()` to execute application containers
   Application containers rely on a minimal init system to run their workloads. Instead of executing it by opening a file that is bind-mounted into the container simply pass a file descriptor to `execveat()`. This makes application container startup safer and simpler.
 
-  #### enable per-thread container name prefix when logging
+  ## enable per-thread container name prefix when logging
   Now each thread that runs a different container but shares a single log file can be identified by printing the name of the container into the log.
 
-  #### refactor cgroup handling
+  ## refactor cgroup handling
   This replaces the constructor implementation of cgroup handling with a simpler, thread-safe on-demand model of cgroup driver initialization.
   Making the cgroup initialization code run in a constructor means that each time the shared library gets mapped the cgroup parsing code gets run. That was unnecessary overhead. The cleaner implementation is to allocate a cgroup driver on demand whenever it is needed.
 
-  #### raise ambient capabilities when running hooks
+  ## raise ambient capabilities when running hooks
   In very restricted containers (e.g. unprivileged containers that only run with a single mapping for a non-root user) it was not possible to perform operations that require privilege during startup.
   By raising ambient capabilities when a hook is run it is possible to preserve privileges across `exec`.
 
-  #### allow to mount `/sys` `rw` in unprivileged containers
+  ## allow to mount `/sys` `rw` in unprivileged containers
   With new kernel work done by the LXD team it is now possible to send uevents inside user namespaces. This means it is time to let `udev` run inside containers. A pre-condition for this is that `/sys` is mounted `rw`. If it is not `udev` will refuse to start.
 
-  #### add `strlcpy()` and `strlcat()` and deprecate `strncpy()` and `strncat()`
+  ## add `strlcpy()` and `strlcat()` and deprecate `strncpy()` and `strncat()`
   This makes string handling safer as `strlcat()` and `strlcpy()` always return a valid string and allow to properly check for truncation.
 
-  #### compiler based hardening
+  ## compiler based hardening
   By default `LXC` will turn on  variety of compiler hardening options  such as:
 
       -Wimplicit-fallthrough
@@ -139,17 +139,17 @@ content: |-
       --mcet -fcf-protection
       -Werror=implicit-function-declaration
 
-  #### thread-safety improvements
+  ## thread-safety improvements
   The codebase has been further hardended to be usable in multi-threaded environments
 
-  #### seccomp: support architecture stacking
+  ## seccomp: support architecture stacking
   This allows to support e.g. the following use-case and more:
   - 64bit kernel and 64bit userspace running 32bit containers
   - 64bit kernel and 32bit userspace running 64bit containers
   -  64bit kernel and 64bit userspace running 32bit containers running 64bit containers
   - ...
 
-  #### support application containers without `uid 0` in the container
+  ## support application containers without `uid 0` in the container
   This allows to start containers that do not have a mapping for `uid 0` inside of the container. 
   Here's an example config:
 
@@ -169,14 +169,14 @@ content: |-
       lxc.init.uid = 1001
       lxc.init.gid = 1001
 
-  #### support `devpts` mounts on kernels without `gid` mount option
+  ## support `devpts` mounts on kernels without `gid` mount option
   Older kernels do not support the `gid` mount option to grant access to a specific group. LXC will now handle this case automatically and only add `gid = 5` if the `gid` mount option is supported by the kernel.
 
-  ### Bugfixes
+  # Bugfixes
   LXC 3.1.0 includes all the same bugfixes as LXC 3.0.1, 3.0.2 and 3.0.3.
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 3.1 isn't a LTS release and so will only be supported until such time as LXC 3.2 is released. We recommend users that need a stronger support commitment to stay on one of our LTS releases.
 
-  ### Downloads
+  # Downloads
    - LXC release tarball: [lxc-3.1.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.1.0.tar.gz) (GPG: [lxc-3.1.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.1.0.tar.gz.asc))

--- a/content/lxc/news/lxc-3.2.1.yaml
+++ b/content/lxc/news/lxc-3.2.1.yaml
@@ -2,23 +2,23 @@ title: LXC 3.2.1 has been released
 date: 2019/07/24 02:07
 origin: https://discuss.linuxcontainers.org/t/lxc-3-2-1-has-been-released/5322
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 3.2.1!
 
   Because of an issue in the 3.2.0 release process, we ended up having to roll a 3.2.1 release almost immediately, fixing an issue in the `configure.ac` file identifying the release as stable.
 
-  ### New features
+  # New features
 
-  #### seccomp: Support syscall forwarding to userspace
+  ## seccomp: Support syscall forwarding to userspace
   Newer kernels allow seccomp to forward intercepted syscalls to a dedicated file descriptor. These messages can be read, the syscall arguments inspected, and if found secure, a sufficiently privileged userspace process can perform the actions normally done by the kernel for the container.
   LXC introduces a new protocol to send and receive messages to another process. User can specify a unix socket address via `lxc.seccomp.notify.proxy` in the format `unix:<path>` to which LXC will forward the intercepted syscalls and will wait for an appropriate response.
   User can set a cookie via `lxc.seccomp.notify.cookie` that LXC will send back to process that reads forwarded syscalls. This will e.g. allow the listening process to identify which container sent a message.
   With this feature LXD e.g. supports device node creation via the `mknod()` and `mknodat()` system calls that are usually forbidden in containers for a well-defined set of secure devices.
 
-  #### Add `lxc.seccomp.allow_nesting` configuration key
+  ## Add `lxc.seccomp.allow_nesting` configuration key
   This release adds the lxc.seccomp.allow_nesting api extension. If `lxc.seccomp.allow_nesting` is set to 1 then seccomp profiles will be stacked. This way nested containers can load their own seccomp policy on top of the policy that the outer container might have applied.
 
-  #### Networking: Add IPVLAN support
+  ## Networking: Add IPVLAN support
   LXC has gained support for IPVLAN. Here is an example how to setup the network:
 
       lxc.net[i].type=ipvlan
@@ -27,15 +27,15 @@ content: |-
       lxc.net[i].link=eth0
       lxc.net[i].flags=up
 
-  #### Networking: Add layer 2 (ARP/NDP) proxy mode
+  ## Networking: Add layer 2 (ARP/NDP) proxy mode
   LXC now supports layer 2 ARP/NDP proxy mode. This can be enabled by using:
 
       lxc.net.[i].l2proxy = [0,1] (defaults to 0)
 
-  #### Networking: Add gateway device route mode
+  ## Networking: Add gateway device route mode
   LXC now supports specifying `lxc.net.[i].ipv4.gateway` and/or `lxc.net.[i].ipv6.gateway` with a value of `dev`. This will cause LXC to set a device route as default gateway.
 
-  #### Networking: Add support for static routes
+  ## Networking: Add support for static routes
   This release introudces two new configuration keys
 
       lxc.net.[i].veth.ipv4.route
@@ -43,7 +43,7 @@ content: |-
 
   which allow users to set static routes on a veth type interfaces.
 
-  #### Networking: Add router veth mode
+  ## Networking: Add router veth mode
   LXC has gained a new router mode for veth networking. This "router" mode will configure the host machine as a router for the container by adding static routes for the container's IPs on the host pointing to the container's host-side veth interface. It will also add static IP proxy entries of either the host's link interface IP or a statically set IP on the host-side veth interface to provide the container a gateway to the host.
 
   Here is an example how to setup the network:
@@ -70,10 +70,10 @@ content: |-
   * Supports layer 3 only mode for setups where BGP (or other routing protocols) are running on the host to distribute container's IPs in the local routing table to the wider network.
   * Containers can optionally have IPs accessible on local LAN at layer 2 using the existing  `l2proxy` and  `link`  settings.
 
-  #### pidfd: Add initial support for the new pidfd api
+  ## pidfd: Add initial support for the new pidfd api
   Newer kernel versions allow interaction with processes through process file descriptors (pidfds). This eliminates various race conditions when e.g. sending signals or retrieving process information. This LXC version make use of the pidfd_send_signal() syscall and the CLONE_PIDFD flag with the clone() syscall.
 
-  #### Hardening: Add more compiler based hardening
+  ## Hardening: Add more compiler based hardening
   Over the last few releases we enabled options compilers provide to harden C codebases. This release enables:
 
       -Wlogical-op
@@ -99,43 +99,43 @@ content: |-
       -pipe
       -fexceptions
 
-  #### Hardening: Remove all stack allocations
+  ## Hardening: Remove all stack allocations
   Stack-based memory allocations (e.g. through `alloca()`) can cause quite severe memory bugs. LXC has therefore removed all stack-based memory allocations and will not allow new code to add any.
 
-  #### Hardening: Add support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/)
+  ## Hardening: Add support for [LGTM](https://lgtm.com/projects/g/lxc/lxc/overview/)
   LXC has gained support for the LGTM code analysis tool. We're happy that LXC's code is currently ranked as A+.
 
-  #### Hardening: Add support for [coccinelle](https://en.wikipedia.org/wiki/Coccinelle_(software))
+  ## Hardening: Add support for [coccinelle](https://en.wikipedia.org/wiki/Coccinelle_(software))
   LXC has gained support for the coccinelle code transformation tool. This allows us to automatically change code eliminating error caused by manually replacing e.g. deprecated functions such as `alloca()`.
 
-  #### Hardening: Compiler based resource cleanup
+  ## Hardening: Compiler based resource cleanup
   The codebase will be slowly switched over to make user of cleanup attributes supported by compilers such as `gcc` and `clang`.
 
-  #### Hardening: Remove `fgets()` from the codebase
+  ## Hardening: Remove `fgets()` from the codebase
   To improve security all uses of `fgets()` have been removed from the codebase. Use of this function in new code is strongly discouraged.
 
-  #### Hardening: Expand close-on-exec usage
+  ## Hardening: Expand close-on-exec usage
   All file descriptors that can be made close-on-exec are now close-on-exec.
 
-  #### Use `/sys/kernel/cgroup/delegate` file for cgroup v2
+  ## Use `/sys/kernel/cgroup/delegate` file for cgroup v2
   This  file  exports  a  list  of  the  cgroups  v2  files  (one  per line) that are delegatable (i.e., whose ownership  should  be  changed  to  the  user  ID  of  the delegatee). LXC will use this to determine how to correctly delegate cgroups.
 
-  #### Handle layouts without cgroups
+  ## Handle layouts without cgroups
   This lets LXC start containers on systems without writable cgroups.
 
-  #### Handle offline cpus in cpuset
+  ## Handle offline cpus in cpuset
   In addition to removing isolated cpus from a container's cgroup LXC will now also remove offline cpus from the container's cpuset.
 
-  #### Generate new boot id for each container
+  ## Generate new boot id for each container
   LXC will now generate a new random boot id for each container and mount it to `/proc/sys/kernel/random/boot_id`. This will allow `systemd` to recognize the boots of each container.
 
-  #### Unified network creation
+  ## Unified network creation
   LXC has a new unified way of creating networks for privileged and unprivileged containers greatly simplifying the code.
 
-  #### Security: [Fix for runC CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
+  ## Security: [Fix for runC CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
   This release comes with  a fix for the privileged container breakout discovered earlier this year. As per our policy we don't consider privileged containers root safe and thus LXC as not received a CVE for this. However, we still provide a fix in this release. For more details see [this blog post](https://people.kernel.org/brauner/runtimes-and-the-curse-of-the-privileged-container).
 
-  ### Bugfixes
+  # Bugfixes
   - lxc-download: Pre-release bump of compat
   - seccomp: open memfd read-write
   - doc: Documents the lxc.net.[i].veth.mode option
@@ -347,8 +347,8 @@ content: |-
   - storage: do not destroy pre-existing rootfs
   - terminal: remove sigwinch command
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 3.2 isn't a LTS release and so will only be supported until such time as LXC 3.3 is released. We recommend users that need a stronger support commitment to stay on one of our LTS releases.
 
-  ### Downloads
+  # Downloads
    - LXC release tarball: [lxc-3.2.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-3.2.1.tar.gz) (GPG: [lxc-3.2.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-3.2.1.tar.gz.asc))

--- a/content/lxc/news/lxc-4.0.0.yaml
+++ b/content/lxc/news/lxc-4.0.0.yaml
@@ -2,14 +2,14 @@ title: LXC 4.0 LTS has been released
 date: 2020/03/25 13:03
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.0!
 
   This is the result of two years of work since the LXC 3.0.0 release and is the fourth LTS release for the LXC project. This release will be supported until June 2025.
 
-  ### Major changes
+  # Major changes
 
-  #### cgroups: Full cgroup2 support
+  ## cgroups: Full cgroup2 support
   LXC 4.0 now fully supports the unified cgroup hierarchy. For this to work the whole cgroup driver had to be rewritten. A consequence of this work is that the cgroup layout for LXC containers had to be changed. Older versions of LXC used the layout:
 
       /sys/fs/cgroup/<controller>/<container-name>/
@@ -55,49 +55,49 @@ content: |-
 
   The restrictions enforced by the unified cgroup hierarchy also mean, that in order to start fully unprivileged containers cooperation is needed on distributions that make use of an init system which manages cgroups. This applies to all distributions that use systemd as their init system. When a container is started from the shell via `lxc-start` or other means one either needs to be root to allow LXC to escape to the root cgroup or the init system needs to be instructed to delegate an empty cgroup. In such scenarios it is wise to set the configuration key `lxc.cgroup.relative` to `1` to prevent LXC from escaping to the root cgroup.
 
-  #### cgroups: Freezer support in CGroup2
+  ## cgroups: Freezer support in CGroup2
   As part of the cgroup2 support work for LXC 4.0 we also added support for cgroup2's implementation of the freezer controller which allows to poll until the cgroup is frozen or unfrozen making freezing and unfreezing container's way more reliable than before.
 
-  #### cgroups: eBPF device controller support in CGroup2
+  ## cgroups: eBPF device controller support in CGroup2
   LXC 4.0 can now make proper use of the cgroup2 device controller. It will automatically create, load, and attach a eBPF program to the container's cgroup and supports dynamic additional and removal of rules. The configuration format is the same as for the legacy cgroup controller. Only the `lxc.cgroup2.devices.` prefix instead of the legacy `lxc.cgroup.devices` prefix needs to be used. LXC continues to support both black- and whitelists.
 
-  #### AppArmor: Deny access to `/proc/acpi/**`
+  ## AppArmor: Deny access to `/proc/acpi/**`
   The default AppArmor profile now denies access to `/proc/acpi/` improving safety.
 
-  #### config: Add `lxc.autodev.tmpfs.size` configuration key
+  ## config: Add `lxc.autodev.tmpfs.size` configuration key
   LXC supports creating a usable minimal `/dev` directory for the container by setting `lxc.autodev = 1` in the container's config file. To do this LXC sets up a `tmpfs` mount on `/dev`. This `tmpfs` mount could not be restricted in prior releases. Now it is possible to set a limit on the size of the `tmpfs` mount by setting `lxc.autodev.tmpfs.size` to the number of bytes that the `tmpfs` should be restricted to use.
 
-  #### config: Add `lxc.selinux.context.keyring` key
+  ## config: Add `lxc.selinux.context.keyring` key
   This allows to specify the `selinux` context to be used for the keyring the container uses.
 
-  #### config: Add `lxc.keyring.session`
+  ## config: Add `lxc.keyring.session`
   Setting this to `1` (default) will cause LXC to create a new session keyring.
 
-  #### file utils: Add `fopen_cached()` and `fdopen_cached`
+  ## file utils: Add `fopen_cached()` and `fdopen_cached`
   These helpers first read a whole file and then make it available as a stream to be read via regular file-based libc apis. This makes LXC's handling of various files more robust where the underlying file can change while it is read.
 
-  #### api: Add new `init_pidfd()` member
+  ## api: Add new `init_pidfd()` member
   LXC 4.0 fully supports the new pidfd kernel api the LXC team has merged in the upstream Linux kernel. The `pidfd` of the container's init process can be requested via `c->init_pidfd(c)`.
 
-  #### memory utils: Add new cleanup api
+  ## memory utils: Add new cleanup api
   LXC 4.0 expands the usage of the compiler's cleanup attribute by introducing new internal apis to define and call cleanup macros for complex resource allocations. We have had extremely positive results decreasing bugs around file descriptor and memory leaks significantly by switching to this new way of cleaning up resources.
 
-  #### lxc-usernsexec: Make it easy to map own uid
+  ## lxc-usernsexec: Make it easy to map own uid
   The `lxc-usernsexec` binary now finds a default mapping as specified in `/etc/subuid` and `/etc/subgid` and writes it via `newuidmap` and `newgidmap`.
 
-  #### seccomp: Add s390 support
+  ## seccomp: Add s390 support
   LXC 4.0's seccomp implementation now supports s390 as architecture.
 
-  #### syscalls: Improve manual syscall implementations
+  ## syscalls: Improve manual syscall implementations
   Whenever a given syscall is not supported or exposed by the underlying `C` library of the system LXC will define syscall stubs for important syscalls or new features it deems extremely valuable. This used to be done by checking for `__NR_<syscall-name>` being defined. But `__NR_<syscall-name>` being defined depended on the correct headers for the currently running kernel LXC was compiled on being installed and would be problematic whenever LXC was compiled on a system running an older kernel but used or deployed on systems that use a new kernel. In such scenarios LXC could not make use of new kernel features even though it should. We now introduce definitions for `__NR_<syscall-name>` whenever the system does not define it already and it is an architecture we support (which is basically any architecture). This way we better handle kernel <-> header version mismatches and compilation <-> deployment kernel mismatches.
 
-  #### network: Improved network device creation and removal
+  ## network: Improved network device creation and removal
   We have reworked how network devices are created, tracked, moved between network namespaces, and are removed making low-level network management way more reliable.
 
-  #### network: Allow moving wireless devices
+  ## network: Allow moving wireless devices
   LXC allowed to move wireless network devices (`nl80211`) into containers. This was broken for a while. With 4.0 the ability to move wireless network devices is restored and improved.
 
-  ### Complete changelog
+  # Complete changelog
   Here is a complete list of all changes in this release:
 
   [details="Full commit list"]
@@ -397,15 +397,15 @@ content: |-
   - tree-wide: fix wrong copy-paste for licenses
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 4.0.0 will be supported until June 2025 and our current LTS release, LXC 3.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXC users to plan an upgrade to the 4.0 branch.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.0.tar.gz)
    - GPG signature: [lxc-4.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.0.tar.gz.asc)
 
-  ### Contributors
+  # Contributors
   The LXC 4.0.0 release was brought to you by a total of 30 contributors.

--- a/content/lxc/news/lxc-4.0.1.yaml
+++ b/content/lxc/news/lxc-4.0.1.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.1 LTS has been released
 date: 2020/04/06 20:04
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-1-lts-has-been-released/7310
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.1!
 
   This is the first bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   This release fixes a number of issues that were reported shortly following the [original 4.0.0 release](https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182). Some of the highlights include:
 
    - Tweak systemd ordering (start after remote-fs.target)
@@ -62,11 +62,11 @@ content: |-
    - Revert "start: remove unnecessary check for valid cgroup_ops"
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.1.tar.gz)
    - GPG signature: [lxc-4.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.1.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.10.yaml
+++ b/content/lxc/news/lxc-4.0.10.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.10 has been released
 date: 2021/07/17 03:07
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-10-has-been-released/11618
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.10!
 
   This is the tenth bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
 
    - Fix issues with less common architectures
@@ -98,11 +98,11 @@ content: |-
    - terminal: fix error handling
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.10.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.10.tar.gz)
    - GPG signature: [lxc-4.0.10.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.10.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.11.yaml
+++ b/content/lxc/news/lxc-4.0.11.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.11 has been released
 date: 2021/10/19 21:10
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-11-has-been-released/12427
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.11!
 
   This is the eleventh bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
 
    - Core scheduling support (`lxc.sched.core`)
@@ -303,11 +303,11 @@ content: |-
    - conf: verify that rootfs is stable after setting up mounts
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.11.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.11.tar.gz)
    - GPG signature: [lxc-4.0.11.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.11.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.12.yaml
+++ b/content/lxc/news/lxc-4.0.12.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.12 has been released
 date: 2022/02/02 23:02
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-12-has-been-released/13288
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.12!
 
   This is the twelfth bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
 
    - Fixed CRIU restoration of containers with pre-created veth interfaces
@@ -81,11 +81,11 @@ content: |-
    - lxccontainer: allow xdev when creating the container dir
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.12.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.12.tar.gz)
    - GPG signature: [lxc-4.0.12.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.12.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.2.yaml
+++ b/content/lxc/news/lxc-4.0.2.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.2 LTS has been released
 date: 2020/04/16 19:04
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-2-lts-has-been-released/7449
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.2!
 
   This is the second bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   This release fixes a number of issues that were reported shortly following the original [4.0.0](https://discuss.linuxcontainers.org/t/lxc-4-0-lts-has-been-released/7182) and [4.0.1](https://discuss.linuxcontainers.org/t/lxc-4-0-1-lts-has-been-released/7310) releases. Some of the highlights include:
 
    - RISC-V 64bit support
@@ -58,11 +58,11 @@ content: |-
    - configure: fix coverity builds
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.2.tar.gz)
    - GPG signature: [lxc-4.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.2.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.3.yaml
+++ b/content/lxc/news/lxc-4.0.3.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.3 LTS has been released
 date: 2020/06/29 14:06
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-3-lts-has-been-released/8285
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.3!
 
   This is the third bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Improvement to cgroupv1/cgroupv2 handling
@@ -87,11 +87,11 @@ content: |-
    - commands: don't flood logs
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.3.tar.gz)
    - GPG signature: [lxc-4.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.3.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.4.yaml
+++ b/content/lxc/news/lxc-4.0.4.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.4 LTS has been released
 date: 2020/08/04 21:08
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-4-lts-has-been-released/8624
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.4!
 
   This is the fourth bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Support for new Linux clone flags (clone into cgroup)
@@ -98,11 +98,11 @@ content: |-
    - conf: ensure that the idmap pointer itself is freed
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.4.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.4.tar.gz)
    - GPG signature: [lxc-4.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.4.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.5.yaml
+++ b/content/lxc/news/lxc-4.0.5.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.5 LTS has been released
 date: 2020/10/22 17:10
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-5-lts-has-been-released/9269
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.5!
 
   This is the fifth bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Support allocating PTS devices from within the container
@@ -63,11 +63,11 @@ content: |-
    - conf: account for early return when sending devpts fd
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.5.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.5.tar.gz)
    - GPG signature: [lxc-4.0.5.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.5.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.6.yaml
+++ b/content/lxc/news/lxc-4.0.6.yaml
@@ -2,12 +2,12 @@ title: LXC 4.0.6 LTS has been released
 date: 2021/01/12 20:01
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-6-lts-has-been-released/9926
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.6!
 
   This is the sixth bugfix release for LXC 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
 
   - Improve handling for compatibility architectures for seccomp
@@ -236,11 +236,11 @@ content: |-
    - make lxc-net hermetic w.r.t. existing dnsmasq config
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.6.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.6.tar.gz)
    - GPG signature: [lxc-4.0.6.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.6.tar.gz.asc)

--- a/content/lxc/news/lxc-4.0.9.yaml
+++ b/content/lxc/news/lxc-4.0.9.yaml
@@ -2,7 +2,7 @@ title: LXC 4.0.9 LTS has been released
 date: 2021/05/06 17:05
 origin: https://discuss.linuxcontainers.org/t/lxc-4-0-9-lts-has-been-released/10999
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 4.0.9!
 
   This is the ninth bugfix release for LXC 4.0 which is supported until June 2025.
@@ -11,7 +11,7 @@ content: |-
 
   The changelog below covers 4.0.6 to 4.0.9.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening. Some of the highlights for this release are:
 
    - Testing improvements including fixes from oss-fuzz
@@ -816,11 +816,11 @@ content: |-
    - attach: introduce explicit personality macro
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-4.0.9.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-4.0.9.tar.gz)
    - GPG signature: [lxc-4.0.9.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-4.0.9.tar.gz.asc)

--- a/content/lxc/news/lxc-5.0.0.yaml
+++ b/content/lxc/news/lxc-5.0.0.yaml
@@ -2,18 +2,18 @@ title: LXC 5.0 LTS has been released
 date: 2022/06/17 17:06
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-lts-has-been-released/14381
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 5.0.0!
 
   This is the result of two years of work since the LXC 4.0.0 release and is the fifth LTS release for the LXC project. This release will be supported until June 2027.
 
-  ### Major changes
-  #### Switch to meson
+  # Major changes
+  ## Switch to meson
   With this release of LXC, autotools is being replaced by `meson` as the build tooling. Compatibility `Makefile` targets are provided for `all`, `install` and `dist`.
 
   This is a change which is particularly relevant for packagers as it otherwise has no user visible impact.
 
-  #### New cgroup configuration options
+  ## New cgroup configuration options
   Four new options were added:
 
    - lxc.cgroup.dir.container
@@ -23,7 +23,7 @@ content: |-
 
   Those allow controlling exactly what cgroup paths will be used for the container itself, for the monitor process, for the moitor process upon container termination as well as allow the container cgroup to be placed inside of a nested (inner) cgroup.
 
-  #### Time namespace support
+  ## Time namespace support
   LXC now supports setting up the time namespace.
   This is done through two new options:
 
@@ -32,7 +32,7 @@ content: |-
 
   Which will apply an offset (anywhere from a few nanoseconds to hours) on top of the main system clock.
 
-  #### VLAN support on VETH devices
+  ## VLAN support on VETH devices
   Two new config options were added to the VETH network devices to control VLAN tagging.
 
    - veth.vlan.id
@@ -40,14 +40,14 @@ content: |-
 
   The former sets the primary (untagged) VLAN while the latter is used to set additional tagged VLANs on the device. This requires the use of VLAN filtering on the parent bridge device.
 
-  #### Configurable transmit/receive queues on VETH devices
+  ## Configurable transmit/receive queues on VETH devices
   Still on VETH devices. It's now possible to customize the number of receive and transmit queues through two new configuration options:
 
    - veth.n_rxqueues
    - veth.n_txqueues
 
 
-  ### Complete changelog
+  # Complete changelog
   Here is a complete list of all changes in this release:
 
   [details="Full commit list"]
@@ -1905,15 +1905,15 @@ content: |-
    - meson: Fix bad strerror_r check
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 5.0 will be supported until June 2027 and our current LTS release, LXC 4.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXC users to plan an upgrade to the 5.0 branch.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-5.0.0.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.0.tar.gz)
    - GPG signature: [lxc-5.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.0.tar.gz.asc)
 
-  ### Contributors
+  # Contributors
   The LXC 5.0 release was brought to you by a total of 65 contributors.

--- a/content/lxc/news/lxc-5.0.1.yaml
+++ b/content/lxc/news/lxc-5.0.1.yaml
@@ -2,12 +2,12 @@ title: LXC 5.0.1 LTS has been released
 date: 2022/07/28 22:07
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-1-lts-has-been-released/14724
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 5.0.1!
 
   This is the first bugfix release for LXC 5.0 which is supported until June 2027.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening.
   Some of the highlights for this release are:
 
@@ -36,11 +36,11 @@ content: |-
    - README: update security mails
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-5.0.1.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.1.tar.gz)
    - GPG signature: [lxc-5.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.1.tar.gz.asc)

--- a/content/lxc/news/lxc-5.0.2.yaml
+++ b/content/lxc/news/lxc-5.0.2.yaml
@@ -2,18 +2,18 @@ title: LXC 5.0.2 LTS has been released
 date: 2023/01/20 19:01
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-2-lts-has-been-released/16210
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 5.0.2!
 
   This is the second bugfix release for LXC 5.0 which is supported until June 2027.
 
-  ### Security fix
+  # Security fix
   This release does fix one CVE which was recently open against LXC.
   [CVE-2022-47952](https://nvd.nist.gov/vuln/detail/CVE-2022-47952) covers the use of `lxc-user-nic` (setuid binary) as a way to uncover the existence of files at locations which would normally not be accessible to the user.
 
   This is classified as a low severity CVE and was reported to us publicly through Github along with a fix. Given this was not released under embargo and given the low impact of this issue, we made the decision to process it as we would any other bugfix to liblxc.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening.
 
   Some of the highlights for this release are:
@@ -88,11 +88,11 @@ content: |-
    - Fix build error on sparc64 caused by using the gold linker
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-5.0.2.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.2.tar.gz)
    - GPG signature: [lxc-5.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.2.tar.gz.asc)

--- a/content/lxc/news/lxc-5.0.3.yaml
+++ b/content/lxc/news/lxc-5.0.3.yaml
@@ -2,12 +2,12 @@ title: LXC 5.0.3 LTS has been released
 date: 2023/07/25 22:07
 origin: https://discuss.linuxcontainers.org/t/lxc-5-0-3-lts-has-been-released/17708
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 5.0.3!
 
   This is the third bugfix release for LXC 5.0 which is supported until June 2027.
 
-  ### Bugfixes
+  # Bugfixes
   As usual this bugfix releases focus on stability and hardening.
 
   Some of the highlights for this release are:
@@ -45,11 +45,11 @@ content: |-
    - github: Update for main branch
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXC 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-5.0.3.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-5.0.3.tar.gz)
    - GPG signature: [lxc-5.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-5.0.3.tar.gz.asc)

--- a/content/lxc/news/lxc-6-0-lts-has-been-released.yaml
+++ b/content/lxc/news/lxc-6-0-lts-has-been-released.yaml
@@ -2,47 +2,47 @@ title: LXC 6.0 LTS has been released
 date: 2024/04/03 20:04
 origin: https://discuss.linuxcontainers.org/t/lxc-6-0-lts-has-been-released/19567
 content: |-
-  ### Introduction
+  # Introduction
   The LXC team is pleased to announce the release of LXC 6.0 LTS!
 
   This is the result of two years of work since the LXC 5.0 release and is the sixth LTS release for the LXC project. This release will be supported until June 2029.
 
-  ### Highlights
-  #### New multi-call binary
+  # Highlights
+  ## New multi-call binary
   A new `tools-multicall=true` configuration option can be used to produce a single `lxc` binary which can then have all other `lxc-XYZ` commands be symlinked to.
 
   This allows for a massive disk space reduction, particularly useful for embedded platforms.
 
-  #### Add a `set_timeout` function to the library
+  ## Add a `set_timeout` function to the library
   A new `set_timeout` function is available on the main `lxc_container` struct and allow for setting a global timeout for interactions with the LXC monitor.
 
   Prior to this, there was no timeout, leading to potential deadlocks as there's also no way to cancel an monitor request.
 
   As a result of adding this new symbol to the library, we have bumped the liblxc symbol version to 1.8.0.
 
-  #### LXC bridge now has IPV6 enabled
+  ## LXC bridge now has IPV6 enabled
   The default `lxcbr0` bridge now comes with IPv6 enabled by default, using an IPv6 ULA subnet.
 
-  #### Support for uid/gid selection in `lxc-usernsexec`
+  ## Support for uid/gid selection in `lxc-usernsexec`
   The `lxc-usernsexec` tool now has both `-u` and `-g` options to control what resulting UID and GID (respectively) the user wishes to use (defaulting to 0/0).
 
-  #### Improvements to `lxc-checkconfig`
+  ## Improvements to `lxc-checkconfig`
   `lxc-checkconfig` now only shows the version if `lxc-start` is present (rather than failing).
   Additionally, it's seen a number of other cosmetic improvements as well as now listing the maximum number of allowed namespaces for every namespace type.
 
-  #### Support for squashfs OCI images
+  ## Support for squashfs OCI images
   The built-in `oci` container template can now handle `squashfs` compressed OCI images through the use of `atomfs`.
 
-  #### Switched from systemd's dbus to dbus-1
+  ## Switched from systemd's dbus to dbus-1
   LXC now uses `libdbus-1` for DBus interactions with systemd rather than using `libsystemd`.
   The reason for this change is that `libdbus-1` is readily available for static builds.
 
-  #### Removed Upstart support
+  ## Removed Upstart support
   Support for the `Upstart` init system has finally been removed from LXC.
 
   This shouldn't really affect anyone at this stage and allowed for cleaning up some logic and config files from our repository.
 
-  ### Full changelog
+  # Full changelog
 
   [details="Changelog"]
    - Read list until process exits
@@ -252,24 +252,24 @@ content: |-
    - lxc.spec: Align SPDX license id
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   LXC 6.0 will be supported until June 2029 and our current LTS release, LXC 5.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXC users to plan an upgrade to the 6.0 branch.
 
-  ### Future release cadence
+  # Future release cadence
   To make new LXC features more readily available to users, we have decided to start producing non-LTS releases again. The planned interval is every 6 months with LXC 6.1 planned for October.
 
   Those releases will not benefit from the LTS guarantees around stability, support and security maintenance and will only be supported until the next release comes out.
 
   Production users will likely want to remain on an LTS release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxc-6.0.0a.tar.gz](https://linuxcontainers.org/downloads/lxc/lxc-6.0.0a.tar.gz)
    - GPG signature: [lxc-6.0.0a.tar.gz.asc](https://linuxcontainers.org/downloads/lxc/lxc-6.0.0a.tar.gz.asc)
 
   **NOTE:** The initial release tarballs (`lxc-6.0.0.tar.gz`) had an incorrect `LXC_DEVEL` line in `meson.build` which didn't line up with the matching git commit. `lxc-6.0.0a.tar.gz` is a re-issue of the release tarball which now properly matches the git tag.
 
-  ### Contributors
+  # Contributors
   The LXC 6.0 release was brought to you by a total of 56 contributors.

--- a/content/lxcfs/news.ja/lxcfs-0.1.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.1.yaml
@@ -20,7 +20,7 @@ content: |-
   -->
   LXCFS の最初のリリースですので、まだ非常に未完成である可能性があり、まだ production 環境で使用しないでください。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.10.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.10.yaml
@@ -13,7 +13,7 @@ content: |-
    * libdbus と使う場合に起こる問題のため、全体的にスレッディングを止めました <!-- Turn off threading globally because of problems with libdbus. -->
    * より systemd に適応するために lxcfs マウントを調整しました <!-- Tweak lxcfs mounts to better accommodate systemd. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.11.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.11.yaml
@@ -2,11 +2,11 @@ title: LXCFS 0.11 リリースのお知らせ
 date: 2015/10/26 00:00
 content: |-
 
-  ### 変更点
+  # 変更点
    * libnih と dbus から glib と GDbus の使用に切り替えました。glib と GDbus はスレッドセーフですので、デフォルトでスレッディングが有効になります。 <!-- Switch from libnih and dbus to glib and GDbus.  Since these are thread-safe, enable threading by default. -->
    * 自身を init.scope 内に配置する新しい systemd に対応しました <!-- Support newer systemd which places itself into init.scope. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.12.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.12.yaml
@@ -15,7 +15,7 @@ content: |-
    * FUSE オプションでキャッシングの時間を 0.5 秒に設定しました。LXC がリブートする前にも 0.5 秒待つように stop hook で設定するようにしました <!-- Set FUSE attr caching to half a second, and ship lxc stop hook to wait half
      a second before reboot. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.13.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.13.yaml
@@ -10,7 +10,7 @@ content: |-
    * 新しいバージョンの systemd ベースのコンテナが起動しないバグをいくつか修正しました。加えて他にもバグを修正しています。 <!-- This fixes several bugs which prevented newer systemd-based containers from
      starting, and some more general bugs. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.14.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.14.yaml
@@ -2,14 +2,14 @@ title: LXCFS 0.14 リリースのお知らせ
 date: 2016/01/07 00:00
 content: |-
 
-  ### 変更点
+  # 変更点
    * cgroup namespace を LXC が扱えるかどうかをチェックするようになりました <!-- Listen to hint from lxc regarding cgroup namespaces. -->
    * libnih からの移行時に混入したいくつかの重要なバグの修正を行いました <!-- Several important bugfixes in code introduced during the switch from libnih. -->
    * swap 使用量のレポートの修正を行いました <!-- Fix to swap usage reporting. -->
    * root cgroup 内のタスクに対する過度な可視性のチェックを修正しました <!-- Fix overly strict visibility checks for tasks in root cgroup. -->
    * テストの多数のバグ修正を行いました <!-- Many fixes to the tests. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.15.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.15.yaml
@@ -9,7 +9,7 @@ content: |-
   
    * 深刻なメモリアロケーションに関するバグの修正を行いました。このバグがあるので 0.14 は使用に適しません <!-- Fixing a critical memory allocation bug which makes 0.14 unusable. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.16.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.16.yaml
@@ -9,7 +9,7 @@ content: |-
   
    * 先の 2 つのリリースにあるメモリアロケーションに関するバグの修正のためのリリースです <!-- This provides a fix for the memory allocation bugs in the last two releases. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.17.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.17.yaml
@@ -2,14 +2,14 @@ title: LXCFS 0.17 リリースのお知らせ
 date: 2016/01/26 00:00
 content: |-
 
-  ### 変更点
+  # 変更点
    * PAM モジュールを追加しました <!-- Add a PAM module -->
    * ユーザが自身の init のすべての cgroup ディレクトリを見ることができるようになりました <!-- Allow users to see all cgroup directories under their init's. -->
    * タスク自身の制限でなく、タスクの init プロセスの cgroup の使用量＋制限を使うようになりました <!-- Use a task's init process' cgroup usage+limits to virtualize procfiles,
      rather than the task's own limits. -->
    * スワップの計算の改良を行いました <!-- Improve swap accounting -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.18.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.18.yaml
@@ -2,12 +2,12 @@ title: LXCFS 0.18 リリースのお知らせ
 date: 2016/02/04 00:00
 content: |-
 
-  ### 変更点
+  # 変更点
    * ほとんどの場合で lxcfs の再起動がサポートされました。ほとんどの機能をライブラリに移動させたためです。このライブラリは SIGUSR1 でリロードされます。
      <!-- Support restarting lxcfs in most cases, by moving most functionality
           into a library which is reloaded on SIGUSR1 -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.2.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.2.yaml
@@ -18,7 +18,7 @@ content: |-
   -->
   さらに、このリリースではテストに対する修正もいくつか含まれています。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.3.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.3.yaml
@@ -7,7 +7,7 @@ content: |-
   -->
   このリリースは LXC 設定ファイルのインストールパスに関する修正をのぞいて 0.2 と同じです。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.4.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.4.yaml
@@ -18,7 +18,7 @@ content: |-
   -->
   このリリースはバグの修正**のみ**を含みます。lxcfsを現在使っている場合はいかなる場合でもすぐに新しいバージョンに置き換えるべきです。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.5.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.5.yaml
@@ -12,7 +12,7 @@ content: |-
   -->
   このバージョンでは cgmanager のバージョンの検出のために configure.ac を調整しました。また、LXC のフックも調整しました。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.6.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.6.yaml
@@ -10,7 +10,7 @@ content: |-
    * メモリとファイルディスクリプタのリークをいくつか修正しました <!-- Fixes some memory and fd leaks. -->
    * /proc/stat の cpu-average の修正を行いました <!-- Fixes cpu-average in /proc/stat. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.7.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.7.yaml
@@ -10,7 +10,7 @@ content: |-
    * /proc/diskstatsに対応しました <!-- Support for /proc/diskstats. -->
    * ハングアップの原因となるバグをいくつか修正しました <!-- Fixes a few bugs that were causing hangs. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.8.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.8.yaml
@@ -2,7 +2,7 @@ title: LXCFS 0.8 リリースのお知らせ
 date: 2015/05/07 00:00
 content: |-
 
-  ### 変更点
+  # 変更点
    * (FUSE の) direct_io モードを使うようになりました <!-- Use direct io -->
    * ファイルとディレクトリのオープンにキャッシュを使うようになり、読み書きの際に再利用するようになりました <!-- Cache file and dir open work and re-use at read/write -->
    * (特に Threading に) 必要な FUSE のオプションを強制するようになりました <!-- Force the fuse options we need (especially threading) -->
@@ -10,7 +10,7 @@ content: |-
    * cpuset の扱いを修正しました <!-- Fix handling of cpusets -->
    * lxc のフックの修正をいくつか行いました <!-- Some fixes for the lxc hook -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-0.9.yaml
+++ b/content/lxcfs/news.ja/lxcfs-0.9.yaml
@@ -9,7 +9,7 @@ content: |-
   
   * lxcfs のクラッシュを修正する Michael McCracken 氏からの修正をマージしました <!-- Fixes from Michael McCracken to fix lxcfs crashes -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   -->

--- a/content/lxcfs/news.ja/lxcfs-2.0.0.beta1.yaml
+++ b/content/lxcfs/news.ja/lxcfs-2.0.0.beta1.yaml
@@ -2,12 +2,12 @@ title: LXCFS 2.0.0.beta1 リリースのお知らせ
 date: 2016/02/09 00:00
 content: |-
 
-  ### 変更点
+  # 変更点
    * /proc/swaps がサポートされました <!-- Add support for /proc/swaps -->
    * 要求があれば systemd cgroup の作成と chown を行うようになりました <!-- Create or chown systemd cgroups if asked -->
    * liblxcfs.so を /usr/lib/lxcfs へ移動しました <!-- Move liblxcfs.so to /usr/lib/lxcfs. -->
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   <!--
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   -->

--- a/content/lxcfs/news.ja/lxcfs-3.0.0.yaml
+++ b/content/lxcfs/news.ja/lxcfs-3.0.0.yaml
@@ -4,7 +4,7 @@ origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-0-has-been-released/1440
 content: |-
 
   
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 3.0.0!
   -->
@@ -17,7 +17,7 @@ content: |-
   このリリースは、LXCFS 2.0.0 のリリース以来 2 年に渡る作業の結果で、
   LXCFS プロジェクトの 2 つ目の LTS リリースとなります。そして 2023 年 6 月までサポートされます。
   
-  ### 主な変更点 <!-- Major changes -->
+  # 主な変更点 <!-- Major changes -->
   <!--
   The most significant change to LXCFS 3.0.0 is the removal of the PAM
   module `libpam-cgfs` which has now been moved to the LXC codebase
@@ -39,7 +39,7 @@ content: |-
   -->
   LXCFS 3.0.0 に含まれるその他のすべての変更はバグフィックスであり、これらの変更は LXCFS 2.0 ブランチにすでにバックポートされているか、今後バックポートされる予定です。つまり非常に軽いアップデートです。
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 3.0.0 will be supported until June 2023 and our current LTS
   release, LXCFS 2.0 will now switch to a slower maintenance pace, only
@@ -54,11 +54,11 @@ content: |-
   -->
   LXCFS チームは、すべての LXCFS ユーザに対して、3.0 ブランチへのアップグレードの計画を立てることを強くおすすめします。libpam-cgfs が LXC へ移動しますので、LXC 3.0 へのアップグレードと同時に LXCFS 3.0 へのアップグレードを行うと、libpam-cgfs の機能を引き続き使えるでしょう。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - リリース tarball: [lxcfs-3.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.0.tar.gz)
    - GPG シグネチャ: [lxcfs-3.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.0.tar.gz.asc)
   
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXCFS 3.0.0 release was brought to you by a total of 16 contributors.
   -->

--- a/content/lxcfs/news.ja/lxcfs-3.0.1.yaml
+++ b/content/lxcfs/news.ja/lxcfs-3.0.1.yaml
@@ -3,7 +3,7 @@ date: 2018/06/05 00:00
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-1-has-been-released/1946
 content: |-
 
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 3.0.1!
   -->
@@ -14,17 +14,17 @@ content: |-
   -->
   Stable に対するバグフィックスのためのリリースですので、大きな変更はありません。バグフィックスと細かな使い勝手の改良にフォーカスしています。
   
-  #### 変更点 <!-- Minor improvements -->
+  ## 変更点 <!-- Minor improvements -->
   
    * FUSE マウントオプションとして `noempty` が使えるようになりました <!-- Add support for the `nonempty` FUSE mount option -->
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 3.0.1 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXCFS 3.0.1 は 2023 年 6 月までサポートされる最新の LTS リリースです。利用可能になった最新のバグ修正リリースに更新することをお勧めします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
   
    - リリース tarball<!-- Main release tarball -->: [lxcfs-3.0.1.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.1.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-3.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.1.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-3.0.2.yaml
+++ b/content/lxcfs/news.ja/lxcfs-3.0.2.yaml
@@ -3,7 +3,7 @@ date: 2018/08/21 00:00
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-2-has-been-released/2503
 content: |-
 
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 3.0.2!
   -->
@@ -14,7 +14,7 @@ content: |-
   -->
   Stable に対するバグフィックスのリリースですので、大きな変更はありません。バグフィックスと細かな使い勝手の改良にフォーカスしています。
   
-  #### バグ修正と改良点 <!-- Bugfixes improvements -->
+  ## バグ修正と改良点 <!-- Bugfixes improvements -->
   
    - travis: coverity に対応しました <!-- add coverity support -->
    - travis: <!-- fix --> `.travis.yml` を修正しました
@@ -23,13 +23,13 @@ content: |-
    - bindings: `write_string()` のロギングを改良しました <!-- better logging for write\_string() -->
   
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 3.0.2 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXCFS 3.0.2 は 2023 年 6 月までサポートされる最新の LTS リリースです。利用可能になった最新のバグ修正リリースに更新することをお勧めします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - リリース tarball <!-- Main release tarball -->: [lxcfs-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.2.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.2.tar.gz.asc)
   

--- a/content/lxcfs/news.ja/lxcfs-3.0.3.yaml
+++ b/content/lxcfs/news.ja/lxcfs-3.0.3.yaml
@@ -3,7 +3,7 @@ date: 2018/11/22 00:00
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-3-has-been-released/3355
 content: |-
 
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 3.0.3!
   -->
@@ -14,18 +14,18 @@ content: |-
   -->
   Stable に対するバグフィックスのリリースですので、大きな変更はありません。バグフィックスと細かな使い勝手の改良にフォーカスしています。
   
-  #### バグ修正と改良点 <!-- Bugfixes improvements -->
+  ## バグ修正と改良点 <!-- Bugfixes improvements -->
   
    - bindings: 二重解放（double free）しないようにしました <!-- prevent double free -->
    - tests: `sys/sysmacros.h` ヘッダの include が欠けていたのを修正しました <!-- include missing sys/sysmacros.h header -->
   
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 3.0.3 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXCFS 3.0.3 は 2023 年 6 月までサポートされる最新の LTS リリースです。利用可能になった最新のバグ修正リリースに更新することをお勧めします。
   
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - リリース tarball <!-- Main release tarball -->: [lxcfs-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.3.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.3.tar.gz.asc)
   

--- a/content/lxcfs/news.ja/lxcfs-3.0.4.yaml
+++ b/content/lxcfs/news.ja/lxcfs-3.0.4.yaml
@@ -2,7 +2,7 @@ title: LXCFS 3.0.4 リリースのお知らせ
 date: 2019/06/21 22:06
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-4-has-been-released/5079
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 3.0.4!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   Stable のバグフィックスリリースですので、大きな変更はありません。バグ修正と細かい使い勝手の改良にフォーカスしています。
 
-  #### バグ修正と改良点 <!-- Bugfixes improvements -->
+  ## バグ修正と改良点 <!-- Bugfixes improvements -->
 
    - cpuinfo: CPU quota ベースで CPU の情報を扱うようになりました <!-- use cpu view based on cpu quotas -->
    - bindings: NULL ポインタへの参照を防ぐようにしました <!-- prevent NULL pointer dereference -->
@@ -21,12 +21,12 @@ content: |-
    - hooks: `lxc.mount.hook` スクリプトに `--skip-cgroup-mounts` フラグを追加しました <!-- Adds --skip-cgroup-mounts flag to lxc.mount.hook script. -->
    - config: RPM spec ファイルを追加しました <!-- Adds RPM spec file. -->
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 3.0.4 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
   -->
   LXCFS 3.0.4 は 2023 年 6 月までサポートされる最新の LTS リリースです。利用可能になった最新のバグ修正リリースに更新することをお勧めします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - リリース tarball <!-- Main release tarball -->: [lxcfs-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.4.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.4.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-3.1.2.yaml
+++ b/content/lxcfs/news.ja/lxcfs-3.1.2.yaml
@@ -2,7 +2,7 @@ title: LXCFS 3.1.2 リリースのお知らせ
 date: 2019/07/24 02:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-1-2-has-been-released/5321
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 3.1.2!
   -->
@@ -13,51 +13,51 @@ content: |-
   -->
   我々は、3.1.0 のリリースを 2 度やり直さなければなりませんでした。最初は、問題のある `Makefile` が原因で問題のあるリリース tarball が生成されてしまいました。そして、LXCFS 3.0.4 のユーザーの一部に影響するアップグレードの問題を修正するために再びリリースを行いました。
 
-  #### 新機能 <!-- New features -->
+  ## 新機能 <!-- New features -->
 
-  #### `/proc/stat` にコンテナごとの CPU 使用率表示を追加 <!-- Add support for per-container cpu usage in `/proc/stat` -->
+  ## `/proc/stat` にコンテナごとの CPU 使用率表示を追加 <!-- Add support for per-container cpu usage in `/proc/stat` -->
   <!--
   Newer LXCFS releases make it possible to virtualize cpu usage per container by using the `cpuacct` cgroup.
   -->
   新しい LXCFS では、`cpuacct` cgroup を使って、コンテナごとの実際の CPU 使用率を仮想化して表示できるようになりました。
 
-  #### ロードアベレージ（`loadavg`）の仮想化 <!-- Add support for load average (`loadavg`) virtualization -->
+  ## ロードアベレージ（`loadavg`）の仮想化 <!-- Add support for load average (`loadavg`) virtualization -->
   <!--
   LXCFS now supports virtualizing `/proc/loadavg`. It will calculate the loadavg for a container based on the `cpu` cgroup.
   -->
   LXCFS は `/proc/loadavg` の仮想化をサポートしました。`cpu` cgroup の情報に基づいて、コンテナに対する実際のロードアベレージを計算します。
 
-  #### cpu クォータに基づく `/proc/cpuinfo` 内の CPU 表示 <!-- Display cpus in `/proc/cpuinfo` based on cpu quotas -->
+  ## cpu クォータに基づく `/proc/cpuinfo` 内の CPU 表示 <!-- Display cpus in `/proc/cpuinfo` based on cpu quotas -->
   <!--
   LXCFS will virtualize the cpus displayed in `/proc/cpuinfo` using the `cpu` cgroup and quotas calculated there.
   -->
   LXCFS は `cpu` cgroup と `cpu` cgroup で計算されたクォータを使って `/proc/cpuinfo` 内に表示される CPU を仮想化します。
 
-  #### `/proc/meminfo` 出力内に存在する swap の無効化が可能に <!-- Allow to disable swap in `/proc/meminfo` output -->
+  ## `/proc/meminfo` 出力内に存在する swap の無効化が可能に <!-- Allow to disable swap in `/proc/meminfo` output -->
   <!--
   This adds the `-u` option to disable swap info output in `/proc/meminfo`.
   -->
   `/proc/meminfo` 内の swap 情報の出力を無効化するために `-u` オプションを追加しました。
 
-  #### `/sys/devices/system/cpu/online` の仮想化 <!-- Virtualize `/sys/devices/system/cpu/online` -->
+  ## `/sys/devices/system/cpu/online` の仮想化 <!-- Virtualize `/sys/devices/system/cpu/online` -->
   <!--
   LXCFS now also partially virtualizes `sysfs`. The first file to virtualize is `/sys/devices/system/cpu/online` per container.
   -->
   LXCFS は部分的に `sysfs` も仮想化するようになりました。仮想化された最初のファイルは、コンテナごとの `/sys/devices/system/cpu/online` ファイルです。
 
-  #### `/proc/uptime` へのより高い精度の出力が可能に <!-- Enable higher precision output in `/proc/uptime` -->
+  ## `/proc/uptime` へのより高い精度の出力が可能に <!-- Enable higher precision output in `/proc/uptime` -->
   <!--
   The calculations for `/proc/uptime` are now more correct.
   -->
   `/proc/uptime` の計算がより正しく行われるようになりました。
 
-  #### FUSE の `nonempty` オプションのサポート <!-- Add support for FUSE `nonempty` option -->
+  ## FUSE の `nonempty` オプションのサポート <!-- Add support for FUSE `nonempty` option -->
   <!--
   The `lxcfs` binary can now be passed the `-d` option. When passed, `lxcfs` will also start when the mountpoint is not empty.
   -->
   `lxcfs` バイナリーに `-d` オプションを指定できるようになりました。このオプションを指定すると、`lxcfs` はマウントポイントが空でなくても起動します。
 
-  #### バグ修正（翻訳なし） <!-- Bugfixes -->
+  ## バグ修正（翻訳なし） <!-- Bugfixes -->
 
   - bindings: ensure that opts is non NULL
   - Makefile: Fix typo in file name
@@ -77,7 +77,7 @@ content: |-
   - travis: fix .travis.yml
   - bindings: fix memory leak in proc_loadavg_read()
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 3.1.2 is only supported until the next feature release of LXCFS.
   For long term support, you should prefer LXCFS 3.0.4 LTS which is supported until June 2023.
@@ -85,6 +85,6 @@ content: |-
   LXCFS 3.1.2 は、LXCFS の次のフィーチャーリリースまでのみサポートされます。
   長期のサポートが必要な場合、2023 年 6 月までサポートされる LXCFS 3.0.4 LTS を使うと良いでしょう。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
    - リリース tarball <!-- Main release tarball -->: [lxcfs-3.1.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.1.2.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-3.1.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.1.2.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.0.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.0.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0 LTS リリースのお知らせ
 date: 2020/03/06 23:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
 
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.0!
@@ -14,8 +14,8 @@ content: |-
   -->
   これは LXCFS 3.0.0 リリース以来、2 年に渡る作業の結果であり、LXCFS プロジェクトにとって 3 つめの LTS リリースとなります。このリリースは 2025 年 6 月までサポートされます。
 
-  ### 主な変更点 <!-- Major changes -->
-  #### リポジトリの再構成 <!-- Repository re-organization -->
+  # 主な変更点 <!-- Major changes -->
+  ## リポジトリの再構成 <!-- Repository re-organization -->
   <!--
   The `LXCFS` repo has been completely reorganized. Prior to LXCFS 4.0 all functionality used to live in a single file. This used to work fine for a long time since LXCFS encompassed a very small set of features. Over the years LXCFS has grown a range of new abilities and has seen major improvements in how various aspects of the system are virtualized for containers. This meant that the single file approach was not feasible anymore.
   -->
@@ -26,7 +26,7 @@ content: |-
   -->
   LXCFS 4.0 で、さまざまな広範囲の仮想化機能を、共通のソースディレクトリー以下の分割されたファイルに移動しました。これにより、ビルドシステムにもさまざまな変更が必要になりました。私たちは autotools ビルドスイートを使い続けてきましたが、LXCFS のビルド方法にも大きな変更が必要になりました。もっとも明らかな変更は、コンパイルされたバイナリーがトップレベルのディレクトリーからソースディレクトリー配下に生成されるようになったことです。LXCFS パッケージを作成しているディストリビューションでは、パッケージツールにこの変更を認識させる必要があるかもしれません。
 
-  #### cgroup2: 新しい単一 cgroup 階層のサポート <!-- Support for the new unified cgroup hierarchy -->
+  ## cgroup2: 新しい単一 cgroup 階層のサポート <!-- Support for the new unified cgroup hierarchy -->
   <!--
   The virtualization abilities of LXCFS are often centered around cgroups, i.e. cgroups are used to calculate container specific values that are shown in various files that provide access to system resources. So far, LXCFS has only supported virtualization based on the legacy cgroup hierarchy. With more systems slowly migrating to the unified cgroup hierarchy we have extended LXCFS to provide the same virtualization abilities based on the unified cgroup hierarchy whenever possible. The qualifying "whenever possible" clause needs to be highlighted. Currently, there are various smaller features that can't be virtualized based on the current implementation of the unified cgroup hierarchy. That might change over time as the unified cgroup hierarchy grows new features in the upstream kernel but we can't guarantee that it will provide full feature parity with the legacy cgroup hierarchy as there is no such guarantee or intention from the kernel developers. We hope however, to come to feature parity in what LXCFS provides.
   When sending patches upstream we would appreciate if you could try to make sure that the legacy cgroup and unified cgroup hierarchy support the new feature alike and provide both implementations in one go whenever possible.
@@ -37,7 +37,7 @@ content: |-
 
   パッチを送る際には、cgroup v1 と v2 階層が新機能を同様にサポートすることを確認し、可能な限り両方の実装を一度に提供していただけるとありがたいです。
 
-  #### cpu shares にもとづく `/proc/cpuinfo` と `/proc/stat` の CPU 情報出力 <!-- `/proc/cpuinfo` and cpu output in `/proc/stat` based on cpu shares -->
+  ## cpu shares にもとづく `/proc/cpuinfo` と `/proc/stat` の CPU 情報出力 <!-- `/proc/cpuinfo` and cpu output in `/proc/stat` based on cpu shares -->
   <!--
   CPU information provided in `cpuinfo` and `stat` in `procfs` can now be based on cpu shares. This can provide a more fine-grained and precise view then the regular virtualization we do but requires more state be kept by LXCFS. For full functionality the legacy `cpu` and `cpuacct` controllers need to be enabled on the system. When the unified hierarchy is used only a very rough approximation can be provided though we expec the `cpu` controller in the unified hierarchy to support some of the features that the `cpu` and `cpuacct` controllers in the legacy hierarchy support. This feature can be enabled by passing the `--enable-cfs` flag to LXCFS.
   -->
@@ -45,7 +45,7 @@ content: |-
 
   cgroup v2（単一階層）が使われた場合は、非常におおまかな近似値のみしか提供できません。cgroup v2 の `cpu`  コントローラーが、cgroup v1 の `cpu` と `cpuacct` コントローラーの機能の一部をサポートすることが期待されます。この機能は `--enable-cfs` フラグを LXCFS に与えると有効になります。
 
-  #### コマンドラインオプションの改良 <!-- Improved command line options -->
+  ## コマンドラインオプションの改良 <!-- Improved command line options -->
   <!--
   LXCFS has grown support for features over time and they have mostly been placed behind new command line options. Some of the options had no long or short options and so the experience could feel a little dated. With LXCFS 4.0 we have updated our command line experience. The following options are now supported:
   -->
@@ -68,13 +68,13 @@ content: |-
         -v, --version        Print lxcfs version
         --enable-pidfd       Use pidfd for process tracking
 
-  #### `/proc/loadavg` の仮想化 <!-- `/proc/loadavg` virtualization -->
+  ## `/proc/loadavg` の仮想化 <!-- `/proc/loadavg` virtualization -->
   <!--
   It is now possible for LXCFS to virtualize `loadavg` output. If  `--enable-loadavg` is passed that LXCFS will provide a container-specific `/proc/loadavg` view based on cgroups.
   -->
   LXCFS が `loadavg` 出力を仮想化できるようになりました。`--enable-loadavg` を指定すると、LXCFS は cgroup にもとづいたコンテナ固有の `/proc/loadavg` を提供します。
 
-  #### `pidfd` がサポートするプロセスの追跡 <!-- `pidfd` supported process tracking -->
+  ## `pidfd` がサポートするプロセスの追跡 <!-- `pidfd` supported process tracking -->
   <!--
   LXCFS needs to keep track of each container's init process in order to correctly virtualize various values. This means LXCFS needs to detect when a container's process has died. Detecting this is suspect to the usual pid reuse races which have plagued Linux for a long time. Newer kernels provide the concept of a pidfd which solves pid reuse problems. When LXCFS is started with `--enable-pidfd` it will make use of this feature when the underlying kernel supports it. This will ensure reliable process tracking.
   -->
@@ -82,7 +82,7 @@ content: |-
 
   新しいカーネルでは、PID 再利用の問題を解決する pidfd の考え方が提供されています。LXCFS を `--enable-pidfd` 付きで起動した場合、カーネルがサポートしている場合はこの機能を使います。これによりプロセス追跡の信頼性が保証されます。
 
-  #### コンパイラベースのハードニング <!-- Compiler based hardening -->
+  ## コンパイラベースのハードニング <!-- Compiler based hardening -->
   <!--
   For a long time LXC has supported compiler based hardening, i.e. a set of well-known compiler and linker options are automatically enabled whenever the compiler or linker support them. The set of currently supported hardening flags is:
   -->
@@ -122,19 +122,19 @@ content: |-
       -fvisibility=hidden
 
 
-  #### コンパイラによる最小限のリソースマネージメント <!-- Minimal compiler based resource management -->
+  ## コンパイラによる最小限のリソースマネージメント <!-- Minimal compiler based resource management -->
   <!--
   As has been the case a long time for LXC, LXCFS will now make use of the cleanup macro feature of `clang` and `gcc` to provide automatic cleanup of resources such as memory and file descriptors. For LXC this has significantly reduced the number of resource leaks and we expect the same to be the case for LXCFS.
   -->
   これまで長い間 LXC で行ってきたのと同様に、LXCFS でも `clang` と `gcc` のクリーンアップマクロ機能を利用して、メモリーやファイルディスクリプターのようなリソースの自動クリーニングを提供します。LXC では、これによりリソースリークの数が大幅に減少しました。LXCFS でも同様になることが期待できます。
 
-  #### サポートする全アーキテクチャーで完全に有効なテストスイート <!-- Full test suite enabled on all supported architectures -->
+  ## サポートする全アーキテクチャーで完全に有効なテストスイート <!-- Full test suite enabled on all supported architectures -->
   <!--
   Prior to the LXCFS 4.0 release we have finally come around to enabling our test-suite on all supported architectures. This will ensure more rigorous testing going forward.
   -->
   LXCFS 4.0 リリースに先立って、サポートする全アーキテクチャーでテストスイートを有効にしました。これにより、今後はより厳格なテストを行うことが保証されます。
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 4.0.0 will be supported until June 2025 and our current LTS release, LXCFS 3.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
   -->
@@ -145,12 +145,12 @@ content: |-
   -->
   すべての LXCFS ユーザーは 4.0 ブランチへアップデートすることを強く推奨します。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.0.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-4.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.0.tar.gz.asc)
 
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXCFS 4.0.0 release was brought to you by a total of 15 contributors.
   -->

--- a/content/lxcfs/news.ja/lxcfs-4.0.1.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.1.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.1 LTS リリースのお知らせ
 date: 2020/03/19 14:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-1-lts-has-been-released/7130
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.1!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の最初のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   This release fixes a number of issues that were reported shortly following the [original 4.0.0 release](https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031). Some of the highlights include:
   -->
@@ -72,7 +72,7 @@ content: |-
    - tests: Silence build output
    - cgroup_fuse: actually make asz check mean something
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -80,7 +80,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable に対するバグ修正リリースにはバグ修正とセキュリティ問題の修正のみが含まれ常に安全ですので、最新のバグ修正リリースを維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.1.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.1.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-4.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.1.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.11.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.11.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.11 リリースのお知らせ
 date: 2021/10/19 21:10
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-11-has-been-released/12426
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.11!
   -->
@@ -18,7 +18,7 @@ content: |-
   -->
   注意: このリリースは元は LXCFS 4.0.10 としてリリースされました。しかしバグがあったのでリリースした tarball にはファイルが足りませんでした。LXCFS 4.0.11 はこの修正を含みます。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -59,7 +59,7 @@ content: |-
    - build: fix lxcfs_fuse.h in release tarball
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -67,7 +67,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.11.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.11.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.11.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.11.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.12.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.12.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.12 リリースのお知らせ
 date: 2022/02/02 23:02
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-12-has-been-released/13287
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.12!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 12 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -40,7 +40,7 @@ content: |-
    - Preseve cpu sum in /proc/stat when cpuset changes
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -48,7 +48,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball: [lxcfs-4.0.12.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.12.tar.gz)
    - GPG signature: [lxcfs-4.0.12.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.12.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.2.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.2.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.2 LTS リリースのお知らせ
 date: 2020/04/07 18:04
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-2-lts-has-been-released/7327
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.2!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 2 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   This release fixes a number of issues that were reported shortly following the [original 4.0.0](https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031) and [4.0.1](https://discuss.linuxcontainers.org/t/lxcfs-4-0-1-lts-has-been-released/7130) releases. Some of the highlights include:
   -->
@@ -31,7 +31,7 @@ content: |-
    - proc_fuse: fix swap calculations
    - tests: Handle different lib paths
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -39,7 +39,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.2.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.2.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.3.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.3.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.3 LTS リリースのお知らせ
 date: 2020/04/17 20:04
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-3-lts-has-been-released/7470
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.3!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 3 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   This release fixes a number of issues that were reported shortly following the [original 4.0.0](https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031), [4.0.1](https://discuss.linuxcontainers.org/t/lxcfs-4-0-1-lts-has-been-released/7130) and [4.0.2](https://discuss.linuxcontainers.org/t/lxcfs-4-0-2-lts-has-been-released/7327) releases. Some of the highlights include:
   -->
@@ -48,7 +48,7 @@ content: |-
    - proc_fuse: improve swap calculation
 
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -56,7 +56,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.3.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.3.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.3.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.4.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.4.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.4 LTS リリースのお知らせ
 date: 2020/06/18 20:06
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-4-lts-has-been-released/8212
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.4!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 4 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -77,7 +77,7 @@ content: |-
    - proc_cpuview: cleanup cpuview_proc_stat()
    - proc_cpuview: cleanup cpuview_init_head()
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -85,7 +85,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.4.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.4.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.4.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.5.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.5.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.5 LTS リリースのお知らせ
 date: 2020/08/03 22:08
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-5-lts-has-been-released/8602
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.5!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 5 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -36,7 +36,7 @@ content: |-
    - proc_fuse: remove unused variable
    - fix type mismatch
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -44,7 +44,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.5.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.5.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.5.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.5.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.6.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.6.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.6 LTS リリースのお知らせ <!-- LXCFS 4.0.6 LTS has been
 date: 2020/10/19 22:10
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-6-lts-has-been-released/9236
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.6!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 6 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -36,7 +36,7 @@ content: |-
    - Set the file size to 4k
    - diskstats: support new fields in 4.18+ kernels
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -44,7 +44,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.6.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.6.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.6.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.6.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.7.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.7.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.7 リリースのお知らせ
 date: 2021/01/08 22:01
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-7-has-been-released/9893
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.6!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 7 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -36,7 +36,7 @@ content: |-
    - swap: Remove now unused variable
    - docs: fix simple typo, throuh -> through
 
-  ### Support and upgrade
+  # Support and upgrade
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -44,7 +44,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.7.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.7.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.7.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.7.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.8.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.8.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.8 LTS リリースのお知らせ <!-- LXCFS 4.0.8 LTS has been
 date: 2021/05/06 17:05
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-8-lts-has-been-released/10998
 content: |-
-  ### お知らせ <!-- Introduction -->
+  # お知らせ <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.8!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 8 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -30,7 +30,7 @@ content: |-
    - 現在のシステムのファイルサイズからファイルサイズを決定するようにしました <!-- Determine the file size from the current system file size -->
    - Github Actions に変更しました <!-- Switch to Github Actions -->
 
-  ### Support and upgrade
+  # Support and upgrade
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -38,7 +38,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.8.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.8.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.8.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.8.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-4.0.9.yaml
+++ b/content/lxcfs/news.ja/lxcfs-4.0.9.yaml
@@ -2,7 +2,7 @@ title: LXCFS 4.0.9 LTS リリースのお知らせ
 date: 2021/07/17 02:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-9-lts-has-been-released/11617
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 4.0.9!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2025 年 6 月までサポートされる LXCFS 4.0 の 9 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -35,7 +35,7 @@ content: |-
    - cgroup_fuse: 問題になりそうな単語の置き換え <!-- replace potentially problematic terminology -->
    - lxcfs: libfuse2, libfuse3 の両方のサポート <!-- handle libfuse2 vs libfuse3 -->
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -43,7 +43,7 @@ content: |-
   LXCFS 4.0 ブランチは 2025 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-4.0.9.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.9.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-4.0.9.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.9.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-5.0.0.yaml
+++ b/content/lxcfs/news.ja/lxcfs-5.0.0.yaml
@@ -2,7 +2,7 @@ title: LXCFS 5.0 LTS リリースのお知らせ <!-- LXCFS 5.0 LTS has been rel
 date: 2022/03/10 23:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-lts-has-been-released/13535
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 5.0.0!
   -->
@@ -13,8 +13,8 @@ content: |-
   -->
   このリリースは LXCFS 4.0.0 をリリースして以来の 2 年間の作業の成果です。そして LXCFS プロジェクトの 4 つ目の LTS リリースです。このリリースは 2027 年 6 月までサポートされます。
 
-  ### 主な変更点 <!-- Major changes -->
-  #### meson への移行 <!-- Switch to meson -->
+  # 主な変更点 <!-- Major changes -->
+  ## meson への移行 <!-- Switch to meson -->
   <!--
   With this release of LXCFS, autotools is being replaced by `meson` as the build tooling. Compatibility `Makefile` targets are provided for `all`, `install` and `dist`.
   -->
@@ -25,25 +25,25 @@ content: |-
   -->
   これは、ユーザーの目に見える変化はなく、特にパッケージ作成者に関係する変更です。
 
-  #### cgroup2 サポート <!-- CGroup2 support -->
+  ## cgroup2 サポート <!-- CGroup2 support -->
   <!--
   LXCFS 5.0 properly detects and handles cgroup2, using the cgroup2 hierarchy to fetch the resource consumption information for the container. It also automatically disables the `cgroup` directory feature when run on a cgroup2 system.
   -->
   LXCFS 5.0 は cgroup2 を適切に検出、処理し、cgroup2 階層を使ってコンテナのリソース消費の情報を取得します。また、cgroup2 システム上で実行すると、`cgroup` ディレクトリ機能が自動的に無効化されます。
 
-  #### /proc/slabinfo のサポート <!-- /proc/slabinfo support -->
+  ## /proc/slabinfo のサポート <!-- /proc/slabinfo support -->
   <!--
   The per-cgroup slab allocation is now used to provide a container view of `/proc/slabinfo`.
   -->
   cgroup ごとの slab アロケーションが、`/proc/slabinfo` のコンテナ内のビューを提供するために使われるようになりました。
 
-  #### /sys/devices/system/cpu/ サポート <!-- /sys/devices/system/cpu/ support -->
+  ## /sys/devices/system/cpu/ サポート <!-- /sys/devices/system/cpu/ support -->
   <!--
   In addition to the existing `/sys/devices/system/cpu/online` support, LXCFS will now virtualize the entire `/sys/devices/system/cpu` directory in order to hide CPUs which aren't available to the container.
   -->
   既存の `/sys/devices/system/cpu/online` のサポートに加えて、LXCFS は `/sys/devices/system/cpu` ディレクトリ全体の仮想化を行うようになりました。これによりコンテナが利用できない CPU を隠蔽するようになりました。
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 5.0.0 will be supported until June 2027 and our current LTS release, LXCFS 4.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
   -->
@@ -54,12 +54,12 @@ content: |-
   -->
   すべての LXCFS ユーザーは 5.0 ブランチへアップデートすることを強く推奨します。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-5.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.0.tar.gz)
    - GPG シグネチャ <!-- GPG signature -->: [lxcfs-5.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.0.tar.gz.asc)
 
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXCFS 5.0.0 release was brought to you by a total of 21 contributors.
   -->

--- a/content/lxcfs/news.ja/lxcfs-5.0.1.yaml
+++ b/content/lxcfs/news.ja/lxcfs-5.0.1.yaml
@@ -2,7 +2,7 @@ title: LXCFS 5.0.1 LTS リリースのお知らせ
 date: 2022/07/26 23:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-1-has-been-released/14709
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 5.0.1!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2027 年 6 月までサポートされる LXCFS 5.0 の初めてのバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -64,7 +64,7 @@ content: |-
    - github: Validate target branch
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -72,7 +72,7 @@ content: |-
   LXCFS 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-5.0.1.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.1.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-5.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.1.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-5.0.2.yaml
+++ b/content/lxcfs/news.ja/lxcfs-5.0.2.yaml
@@ -2,7 +2,7 @@ title: LXCFS 5.0.2 LTS リリースのお知らせ
 date: 2022/08/09 21:08
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-2-lts-has-been-released/14811
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 5.0.2!
   -->
@@ -18,7 +18,7 @@ content: |-
   -->
   FUSE3 と同時に使用した場合に LXCFS 5.0.1 がクラッシュする重大な問題を修正しました。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -35,7 +35,7 @@ content: |-
    - fuse3 での再初期化時の問題の修正 <!-- fix reinitialization with fuse3 -->
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -43,7 +43,7 @@ content: |-
   LXCFS 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-5.0.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.2.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-5.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.2.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-5.0.3.yaml
+++ b/content/lxcfs/news.ja/lxcfs-5.0.3.yaml
@@ -2,7 +2,7 @@ title: LXCFS 5.0.3 LTS リリースのお知らせ
 date: 2023/01/17 02:01
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-3-lts-has-been-released/16167
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 5.0.3!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2027 年 6 月までサポートされる LXCFS 5.0 の 3 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -51,7 +51,7 @@ content: |-
    - cpuview: fix ABBA deadlock in find_proc_stat_nod
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -59,7 +59,7 @@ content: |-
   LXCFS 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-5.0.3.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.3.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-5.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.3.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-5.0.4.yaml
+++ b/content/lxcfs/news.ja/lxcfs-5.0.4.yaml
@@ -2,7 +2,7 @@ title: LXCFS 5.0.4 LTS リリースのお知らせ
 date: 2023/07/25 22:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-4-lts-has-been-released/17707
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 5.0.4!
   -->
@@ -13,7 +13,7 @@ content: |-
   -->
   これは 2027 年 6 月までサポートされる LXCFS 5.0 の 4 回目のバグフィックスリリースです。
 
-  ### バグ修正 <!-- Bugfixes -->
+  # バグ修正 <!-- Bugfixes -->
   <!--
   Some of the highlights for this release are:
   -->
@@ -38,7 +38,7 @@ content: |-
    - github: Update for main branch
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
@@ -46,7 +46,7 @@ content: |-
   LXCFS 5.0 ブランチは 2027 年 6 月までサポートされます。
   stable のバグフィックスリリースでは、バグとセキュリティに関する問題に対する修正のみが行われますので、常に安全です。最新のバグフィックスリリースの状態を維持し、実行することをおすすめします。
 
-  ### ダウンロード <!-- Downloads -->
+  # ダウンロード <!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-5.0.4.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.4.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-5.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.4.tar.gz.asc)

--- a/content/lxcfs/news.ja/lxcfs-6-0-lts-has-been-released.yaml
+++ b/content/lxcfs/news.ja/lxcfs-6-0-lts-has-been-released.yaml
@@ -2,7 +2,7 @@ title: LXCFS 6.0 LTS リリースのお知らせ
 date: 2024/04/01 04:04
 origin: https://discuss.linuxcontainers.org/t/lxcfs-6-0-lts-has-been-released/19546
 content: |-
-  ### はじめに <!-- Introduction -->
+  # はじめに <!-- Introduction -->
   <!--
   The LXCFS team is pleased to announce the release of LXCFS 6.0 LTS!
   -->
@@ -13,8 +13,8 @@ content: |-
   -->
   このリリースは、LXCFS 5.0 リリース以来 2 年の取り組みの結果で、LXCFS プロジェクトの 5 つ目の LTS リリースです。
 
-  ### ハイライト <!-- Highlights -->
-  #### 新しい `--enable-cgroup` オプション <!-- New `\-\-enable-cgroup option` -->
+  # ハイライト <!-- Highlights -->
+  ## 新しい `--enable-cgroup` オプション <!-- New `\-\-enable-cgroup option` -->
   <!--
   LXCFS can provide a virtual cgroupfs (v1) tree for use by containers.
   This feature was implemented prior to cgroup namespaces being implemented in the kernel and effectively allow providing a similar experience on kernels lacking that feature.
@@ -27,7 +27,7 @@ content: |-
   -->
   今では、サポートされているほとんどの Linux ディストリビューションは、すべて cgroup namespace をサポートするカーネルを提供しており、新しいディストリビューションのほとんどは cgroup v1 から（v2 に）切り替わっているので、この機能をデフォルトで有効にし続ける意味がありません。そのため、この機能は新しい起動時の引数である `--enable-cgroup` で有効にするようになりました。
 
-  #### CPU の `/sys/devices/system/cpu` での非マスク化 <!-- CPUs no longer masked in /sys/devices/system/cpu -->
+  ## CPU の `/sys/devices/system/cpu` での非マスク化 <!-- CPUs no longer masked in /sys/devices/system/cpu -->
   <!--
   LXCFS 5.0 shipped with logic to filter out entries in `/sys/devices/system/cpu` based on what CPUs were allowed in the caller's cpuset. This behavior doesn't actually reflect the behavior on normal systems where even offline CPUs still show up in `/sys/devices/system/cpu`.
   -->
@@ -38,7 +38,7 @@ content: |-
   -->
   このため、LXCFS 6.0 ではこのロジックを逆転し、オンライン・オフラインの CPU のリストを最新に保つようになっただけで、個々の CPU ディレクトリーにはすべてアクセス可能なままです。
 
-  ### すべての変更点 <!-- Full changelog -->
+  # すべての変更点 <!-- Full changelog -->
 
   [details="すべてのChangeLogを見る"]
    - lxcfs_fuse: ensure lxcfs_fuse_compat.h is included after including fuse header
@@ -126,7 +126,7 @@ content: |-
    - cgroup_utils: explicitly check for cgroup2 FDs in cgroup_walkup_to_root
   [/details]
 
-  ### サポートとアップグレード <!-- Support and upgrade -->
+  # サポートとアップグレード <!-- Support and upgrade -->
   <!--
   LXCFS 6.0 will be supported until June 2029 and our current LTS release, LXCFS 5.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
   -->
@@ -137,7 +137,7 @@ content: |-
   -->
   LXCFS のユーザーはすべて、6.0 ブランチへのアップグレードを計画することを強くおすすめします。
 
-  ### 今後のリリースについて <!-- Future release cadence -->
+  # 今後のリリースについて <!-- Future release cadence -->
   <!--
   To make new LXCFS features more readily available to users, we have decided to start producing non-LTS releases again. The planned interval is every 6 months with LXCFS 6.1 planned for October.
   -->
@@ -153,12 +153,12 @@ content: |-
   -->
   本番環境のユーザーは LTS リリースを利用し続けたいと思うでしょう。
 
-  ### ダウンロード<!-- Downloads -->
+  # ダウンロード<!-- Downloads -->
 
    - リリース tarball <!-- Main release tarball -->: [lxcfs-6.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-6.0.0.tar.gz)
    - GPG シグネチャー <!-- GPG signature -->: [lxcfs-6.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-6.0.0.tar.gz.asc)
 
-  ### コントリビューター <!-- Contributors -->
+  # コントリビューター <!-- Contributors -->
   <!--
   The LXCFS 6.0 release was brought to you by a total of 25 contributors.
   -->

--- a/content/lxcfs/news/lxcfs-0.1.yaml
+++ b/content/lxcfs/news/lxcfs-0.1.yaml
@@ -11,5 +11,5 @@ content: |-
   Note that as the first release of LXCFS, things can still be very rough and we would advice
   against using this in production.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).

--- a/content/lxcfs/news/lxcfs-0.10.yaml
+++ b/content/lxcfs/news/lxcfs-0.10.yaml
@@ -10,6 +10,6 @@ content: |-
    * Turn off threading globally because of problems with libdbus.
    * Tweak lxcfs mounts to better accommodate systemd.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   

--- a/content/lxcfs/news/lxcfs-0.11.yaml
+++ b/content/lxcfs/news/lxcfs-0.11.yaml
@@ -2,11 +2,11 @@ title: LXCFS 0.11 release announcement
 date: 2015/10/26 00:00
 content: |-
 
-  ### Changes
+  # Changes
    * Switch from libnih and dbus to glib and GDbus.  Since these are
      thread-safe, enable threading by default.
    * Support newer systemd which places itself into init.scope.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   

--- a/content/lxcfs/news/lxcfs-0.12.yaml
+++ b/content/lxcfs/news/lxcfs-0.12.yaml
@@ -12,6 +12,6 @@ content: |-
    * Set FUSE attr caching to half a second, and ship lxc stop hook to wait half
      a second before reboot.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   

--- a/content/lxcfs/news/lxcfs-0.13.yaml
+++ b/content/lxcfs/news/lxcfs-0.13.yaml
@@ -7,6 +7,6 @@ content: |-
    * This fixes several bugs which prevented newer systemd-based containers from
      starting, and some more general bugs.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   

--- a/content/lxcfs/news/lxcfs-0.14.yaml
+++ b/content/lxcfs/news/lxcfs-0.14.yaml
@@ -2,13 +2,13 @@ title: LXCFS 0.14 release announcement
 date: 2016/01/07 00:00
 content: |-
 
-  ### Changes
+  # Changes
    * Listen to hint from lxc regarding cgroup namespaces.
    * Several important bugfixes in code introduced during the switch from libnih.
    * Fix to swap usage reporting.
    * Fix overly strict visibility checks for tasks in root cgroup.
    * Many fixes to the tests.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   

--- a/content/lxcfs/news/lxcfs-0.15.yaml
+++ b/content/lxcfs/news/lxcfs-0.15.yaml
@@ -6,6 +6,6 @@ content: |-
   
    * Fixing a critical memory allocation bug which makes 0.14 unusable.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   

--- a/content/lxcfs/news/lxcfs-0.16.yaml
+++ b/content/lxcfs/news/lxcfs-0.16.yaml
@@ -6,6 +6,6 @@ content: |-
   
    * This provides a fix for the memory allocation bugs in the last two releases.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   

--- a/content/lxcfs/news/lxcfs-0.17.yaml
+++ b/content/lxcfs/news/lxcfs-0.17.yaml
@@ -2,13 +2,13 @@ title: LXCFS 0.17 release announcement
 date: 2016/01/26 00:00
 content: |-
 
-  ### Changes
+  # Changes
    * Add a PAM module
    * Allow users to see all cgroup directories under their init's.
    * Use a task's init process' cgroup usage+limits to virtualize procfiles,
      rather than the task's own limits.
    * Improve swap accounting
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   

--- a/content/lxcfs/news/lxcfs-0.18.yaml
+++ b/content/lxcfs/news/lxcfs-0.18.yaml
@@ -2,10 +2,10 @@ title: LXCFS 0.18 release announcement
 date: 2016/02/04 00:00
 content: |-
 
-  ### Changes
+  # Changes
    * Support restarting lxcfs in most cases, by moving most functionality
      into a library which is reloaded on SIGUSR1
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   

--- a/content/lxcfs/news/lxcfs-0.2.yaml
+++ b/content/lxcfs/news/lxcfs-0.2.yaml
@@ -9,7 +9,7 @@ content: |-
   
   Additionally this release also includes some fixes to the testsuite.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   
   

--- a/content/lxcfs/news/lxcfs-0.3.yaml
+++ b/content/lxcfs/news/lxcfs-0.3.yaml
@@ -4,7 +4,7 @@ content: |-
 
   This release is identical to 0.2 except for a fixed installation path of the LXC configuration file.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   
   

--- a/content/lxcfs/news/lxcfs-0.4.yaml
+++ b/content/lxcfs/news/lxcfs-0.4.yaml
@@ -9,7 +9,7 @@ content: |-
   
   This release includes ONLY this bugfix and should be immediately deployed by anyone currently using lxcfs.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   
   

--- a/content/lxcfs/news/lxcfs-0.5.yaml
+++ b/content/lxcfs/news/lxcfs-0.5.yaml
@@ -6,7 +6,7 @@ content: |-
   
   This tweaks configure.ac to detect cgmanager version and tweak the LXC hook.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   
   

--- a/content/lxcfs/news/lxcfs-0.6.yaml
+++ b/content/lxcfs/news/lxcfs-0.6.yaml
@@ -7,7 +7,7 @@ content: |-
    * Fixes some memory and fd leaks.
    * Fixes cpu-average in /proc/stat.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   
   

--- a/content/lxcfs/news/lxcfs-0.7.yaml
+++ b/content/lxcfs/news/lxcfs-0.7.yaml
@@ -7,7 +7,7 @@ content: |-
    * Support for /proc/diskstats.
    * Fixes a few bugs that were causing hangs.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   
   

--- a/content/lxcfs/news/lxcfs-0.8.yaml
+++ b/content/lxcfs/news/lxcfs-0.8.yaml
@@ -2,7 +2,7 @@ title: LXCFS 0.8 release announcement
 date: 2015/05/07 00:00
 content: |-
 
-  ### Changes
+  # Changes
    * Use direct io
    * Cache file and dir open work and re-use at read/write
    * Force the fuse options we need (especially threading)
@@ -10,6 +10,6 @@ content: |-
    * Fix handling of cpusets
    * Some fixes for the lxc hook
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   

--- a/content/lxcfs/news/lxcfs-0.9.yaml
+++ b/content/lxcfs/news/lxcfs-0.9.yaml
@@ -6,6 +6,6 @@ content: |-
   
    * Fixes from Michael McCracken to fix lxcfs crashes
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads/).
   

--- a/content/lxcfs/news/lxcfs-2.0.0.beta1.yaml
+++ b/content/lxcfs/news/lxcfs-2.0.0.beta1.yaml
@@ -2,11 +2,11 @@ title: LXCFS 2.0.0.beta1 release announcement
 date: 2016/02/09 00:00
 content: |-
 
-  ### Changes
+  # Changes
    * Add support for /proc/swaps
    * Create or chown systemd cgroups if asked
    * Move liblxcfs.so to /usr/lib/lxcfs.
   
-  ### Downloads
+  # Downloads
   The release tarballs can be found on our [download page](/lxcfs/downloads).
   

--- a/content/lxcfs/news/lxcfs-3.0.0.yaml
+++ b/content/lxcfs/news/lxcfs-3.0.0.yaml
@@ -2,28 +2,28 @@ title: LXCFS 3.0.0 has been released
 date: 2018/03/27 03:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-0-has-been-released/1440
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 3.0.0!
 
   This is the result of two years of work since the LXCFS 2.0.0 release
   This is the second LTS release for the LXCFS project and will be supported until June 2023.
 
-  ### Major changes
+  # Major changes
   The most significant change to LXCFS 3.0.0 is the removal of the PAM module `libpam-cgfs` which has now been moved to the LXC codebase instead.
 
   This was motivated by the fact that all LXC users, whether they use LXCFS or not can benefit from that PAM module and that much more code can be shared with LXC than it could with LXCFS.
 
   All other changes included in LXCFS 3.0.0 are considered to be bugfixes and have or will be backported to the LXCFS 2.0 branch, making this a very lightweight update.
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 3.0.0 will be supported until June 2023 and our current LTS release, LXCFS 2.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXCFS users to plan an upgrade to the 3.0 branch.
   Due to the transition of libpam-cgfs to LXC, this should be done at the same time as the upgrade to LXC 3.0 to avoid regressions.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxcfs-3.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.0.tar.gz)
    - GPG signature: [lxcfs-3.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.0.tar.gz.asc)
 
-  ### Contributors
+  # Contributors
   The LXCFS 3.0.0 release was brought to you by a total of 16 contributors.

--- a/content/lxcfs/news/lxcfs-3.0.2.yaml
+++ b/content/lxcfs/news/lxcfs-3.0.2.yaml
@@ -2,12 +2,12 @@ title: LXCFS 3.0.2 has been released
 date: 2018/08/21 15:08
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-2-has-been-released/2503
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 3.0.2!
 
   As a stable bugfix release, no major changes have been done, instead focusing on bugfixes and minor usability improvements.
 
-  #### Bugfixes improvements
+  ## Bugfixes improvements
 
    - travis: add coverity support
    - travis: fix .travis.yml
@@ -16,9 +16,9 @@ content: |-
    - bindings: better logging for write_string()
 
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 3.0.2 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxcfs-3.0.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.2.tar.gz)
    - GPG signature: [lxcfs-3.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.2.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-3.0.3.yaml
+++ b/content/lxcfs/news/lxcfs-3.0.3.yaml
@@ -2,19 +2,19 @@ title: LXCFS 3.0.3 has been released
 date: 2018/11/23 01:11
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-3-has-been-released/3355
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 3.0.3!
 
   As a stable bugfix release, no major changes have been done, instead focusing on bugfixes and minor usability improvements.
 
-  #### Bugfixes improvements
+  ## Bugfixes improvements
 
    - bindings: prevent double free
    - tests: include missing sys/sysmacros.h header
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 3.0.3 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxcfs-3.0.3.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.3.tar.gz)
    - GPG signature: [lxcfs-3.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.3.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-3.0.4.yaml
+++ b/content/lxcfs/news/lxcfs-3.0.4.yaml
@@ -2,12 +2,12 @@ title: LXCFS 3.0.4 has been released
 date: 2019/06/21 22:06
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-0-4-has-been-released/5079
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 3.0.4!
 
   As a stable bugfix release, no major changes have been done, instead focusing on bugfixes and minor usability improvements.
 
-  #### Bugfixes improvements
+  ## Bugfixes improvements
 
    - cpuinfo: use cpu view based on cpu quotas
    - bindings: prevent NULL pointer dereference
@@ -15,9 +15,9 @@ content: |-
    - hooks: Adds --skip-cgroup-mounts flag to lxc.mount.hook script.
    - config: Adds RPM spec file.
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 3.0.4 is supported until June 2023 and is our current LTS release, users are encouraged to update to the latest bugfix releases as they're made available.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxcfs-3.0.4.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.4.tar.gz)
    - GPG signature: [lxcfs-3.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.0.4.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-3.1.2.yaml
+++ b/content/lxcfs/news/lxcfs-3.1.2.yaml
@@ -2,35 +2,35 @@ title: LXCFS 3.1.2 has been released
 date: 2019/07/24 02:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-3-1-2-has-been-released/5321
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 3.1.2!
 
   We had to re-roll the 3.1.0 release twice, first because of a bad Makefile causing an invalid release tarball to be generated, then again to fix an upgrade issue affecting some users of LXCFS 3.0.4
 
-  #### New features
+  ## New features
 
-  #### Add support for per-container cpu usage in `/proc/stat`
+  ## Add support for per-container cpu usage in `/proc/stat`
   Newer LXCFS releases make it possible to virtualize cpu usage per container by using the `cpuacct` cgroup.
 
-  #### Add support for load average (`loadavg`) virtualization
+  ## Add support for load average (`loadavg`) virtualization
   LXCFS now supports virtualizing `/proc/loadavg`. It will calculate the loadavg for a container based on the `cpu` cgroup.
 
-  #### Display cpus in `/proc/cpuinfo` based on cpu quotas
+  ## Display cpus in `/proc/cpuinfo` based on cpu quotas
   LXCFS will virtualize the cpus displayed in `/proc/cpuinfo` using the `cpu` cgroup and quotas calculated there.
 
-  #### Allow to disable swap in `/proc/meminfo` output
+  ## Allow to disable swap in `/proc/meminfo` output
   This adds the `-u` option to disable swap info output in `/proc/meminfo`.
 
-  #### Virtualize `/sys/devices/system/cpu/online`
+  ## Virtualize `/sys/devices/system/cpu/online`
   LXCFS now also partially virtualizes `sysfs`. The first file to virtualize is `/sys/devices/system/cpu/online` per container.
 
-  #### Enable higher precision output in `/proc/uptime`
+  ## Enable higher precision output in `/proc/uptime`
   The calculations for `/proc/uptime` are now more correct.
 
-  #### Add support for FUSE `nonempty` option
+  ## Add support for FUSE `nonempty` option
   The `lxcfs` binary can now be passed the `-d` option. When passed, `lxcfs` will also start when the mountpoint is not empty.
 
-  #### Bugfixes
+  ## Bugfixes
 
   - bindings: ensure that opts is non NULL
   - Makefile: Fix typo in file name
@@ -50,10 +50,10 @@ content: |-
   - travis: fix .travis.yml
   - bindings: fix memory leak in proc_loadavg_read()
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 3.1.2 is only supported until the next feature release of LXCFS.
   For long term support, you should prefer LXCFS 3.0.4 LTS which is supported until June 2023.
 
-  ### Downloads
+  # Downloads
    - Main release tarball: [lxcfs-3.1.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.1.2.tar.gz)
    - GPG signature: [lxcfs-3.1.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-3.1.2.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.0.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.0.yaml
@@ -2,25 +2,25 @@ title: LXCFS 4.0 LTS has been released
 date: 2020/03/06 23:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.0!
 
   This is the result of two years of work since the LXCFS 3.0.0 release and is the third LTS release for the LXCFS project. This release will be supported until June 2025.
 
-  ### Major changes
-  #### Repository re-organization
+  # Major changes
+  ## Repository re-organization
   The `LXCFS` repo has been completely reorganized. Prior to LXCFS 4.0 all functionality used to live in a single file. This used to work fine for a long time since LXCFS encompassed a very small set of features. Over the years LXCFS has grown a range of new abilities and has seen major improvements in how various aspects of the system are virtualized for containers. This meant that the single file approach was not feasible anymore.
 
   With LXCFS 4.0 various large virtualization features have been moved into separate files under a common source directory. This has also necessitated various changes to the build system. While we have stuck with the autotools build suite we have had to make significant changes how LXCFS is built. The most obvious change is that the location of the compiled binaries has changed from the top level directory under the source directory. For distributions packaging LXCFS this might mean that the package tooling needs to be made aware of this.
 
-  #### cgroup2: Support for the new unified cgroup hierarchy
+  ## cgroup2: Support for the new unified cgroup hierarchy
   The virtualization abilities of LXCFS are often centered around cgroups, i.e. cgroups are used to calculate container specific values that are shown in various files that provide access to system resources. So far, LXCFS has only supported virtualization based on the legacy cgroup hierarchy. With more systems slowly migrating to the unified cgroup hierarchy we have extended LXCFS to provide the same virtualization abilities based on the unified cgroup hierarchy whenever possible. The qualifying "whenever possible" clause needs to be highlighted. Currently, there are various smaller features that can't be virtualized based on the current implementation of the unified cgroup hierarchy. That might change over time as the unified cgroup hierarchy grows new features in the upstream kernel but we can't guarantee that it will provide full feature parity with the legacy cgroup hierarchy as there is no such guarantee or intention from the kernel developers. We hope however, to come to feature parity in what LXCFS provides.
   When sending patches upstream we would appreciate if you could try to make sure that the legacy cgroup and unified cgroup hierarchy support the new feature alike and provide both implementations in one go whenever possible.
 
-  #### `/proc/cpuinfo` and cpu output in `/proc/stat` based on cpu shares
+  ## `/proc/cpuinfo` and cpu output in `/proc/stat` based on cpu shares
   CPU information provided in `cpuinfo` and `stat` in `procfs` can now be based on cpu shares. This can provide a more fine-grained and precise view then the regular virtualization we do but requires more state be kept by LXCFS. For full functionality the legacy `cpu` and `cpuacct` controllers need to be enabled on the system. When the unified hierarchy is used only a very rough approximation can be provided though we expec the `cpu` controller in the unified hierarchy to support some of the features that the `cpu` and `cpuacct` controllers in the legacy hierarchy support. This feature can be enabled by passing the `--enable-cfs` flag to LXCFS.
 
-  #### Improved command line options
+  ## Improved command line options
   LXCFS has grown support for features over time and they have mostly been placed behind new command line options. Some of the options had no long or short options and so the experience could feel a little dated. With LXCFS 4.0 we have updated our command line experience. The following options are now supported:
 
       Usage: lxcfs <directory>
@@ -40,13 +40,13 @@ content: |-
         -v, --version        Print lxcfs version
         --enable-pidfd       Use pidfd for process tracking
 
-  #### `/proc/loadavg` virtualization
+  ## `/proc/loadavg` virtualization
   It is now possible for LXCFS to virtualize `loadavg` output. If  `--enable-loadavg` is passed that LXCFS will provide a container-specific `/proc/loadavg` view based on cgroups.
 
-  #### `pidfd` supported process tracking
+  ## `pidfd` supported process tracking
   LXCFS needs to keep track of each container's init process in order to correctly virtualize various values. This means LXCFS needs to detect when a container's process has died. Detecting this is suspect to the usual pid reuse races which have plagued Linux for a long time. Newer kernels provide the concept of a pidfd which solves pid reuse problems. When LXCFS is started with `--enable-pidfd` it will make use of this feature when the underlying kernel supports it. This will ensure reliable process tracking.
 
-  #### Compiler based hardening
+  ## Compiler based hardening
   For a long time LXC has supported compiler based hardening, i.e. a set of well-known compiler and linker options are automatically enabled whenever the compiler or linker support them. The set of currently supported hardening flags is:
 
       -Wimplicit-fallthrough=5
@@ -83,21 +83,21 @@ content: |-
       -fvisibility=hidden
 
 
-  #### Minimal compiler based resource management
+  ## Minimal compiler based resource management
   As has been the case a long time for LXC, LXCFS will now make use of the cleanup macro feature of `clang` and `gcc` to provide automatic cleanup of resources such as memory and file descriptors. For LXC this has significantly reduced the number of resource leaks and we expect the same to be the case for LXCFS.
 
-  #### Full test suite enabled on all supported architectures
+  ## Full test suite enabled on all supported architectures
   Prior to the LXCFS 4.0 release we have finally come around to enabling our test-suite on all supported architectures. This will ensure more rigorous testing going forward.
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 4.0.0 will be supported until June 2025 and our current LTS release, LXCFS 3.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXCFS users to plan an upgrade to the 4.0 branch.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.0.tar.gz)
    - GPG signature: [lxcfs-4.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.0.tar.gz.asc)
 
-  ### Contributors
+  # Contributors
   The LXCFS 4.0.0 release was brought to you by a total of 15 contributors.

--- a/content/lxcfs/news/lxcfs-4.0.1.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.1.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.1 LTS has been released
 date: 2020/03/19 14:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-1-lts-has-been-released/7130
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.1!
 
   This is the first bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   This release fixes a number of issues that were reported shortly following the [original 4.0.0 release](https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031). Some of the highlights include:
 
    - CPU view (CFS) on CgroupV2 systems
@@ -62,11 +62,11 @@ content: |-
    - cgroup_fuse: actually make asz check mean something
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.1.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.1.tar.gz)
    - GPG signature: [lxcfs-4.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.1.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.11.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.11.yaml
@@ -2,14 +2,14 @@ title: LXCFS 4.0.11 has been released
 date: 2021/10/19 21:10
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-11-has-been-released/12426
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.11!
 
   This is the eleventh bugfix release for LXCFS 4.0 which is supported until June 2025.
 
   NOTE: This was originally released as LXCFS 4.0.10 but a bug caused the published release tarball to be missing a file. LXCFS 4.0.11 includes that fix.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Fixed a potential deadlock in the cpuinfo handler
@@ -44,11 +44,11 @@ content: |-
    - build: fix lxcfs_fuse.h in release tarball
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.11.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.11.tar.gz)
    - GPG signature: [lxcfs-4.0.11.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.11.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.12.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.12.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.12 has been released
 date: 2022/02/02 23:02
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-12-has-been-released/13287
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.12!
 
   This is the twelfth bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - CPU sum in /proc/stat is now preserved on cpuset changes
@@ -28,11 +28,11 @@ content: |-
    - Preseve cpu sum in /proc/stat when cpuset changes
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.12.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.12.tar.gz)
    - GPG signature: [lxcfs-4.0.12.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.12.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.2.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.2.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.2 LTS has been released
 date: 2020/04/07 18:04
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-2-lts-has-been-released/7327
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.2!
 
   This is the second bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   This release fixes a number of issues that were reported shortly following the [original 4.0.0](https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031) and [4.0.1](https://discuss.linuxcontainers.org/t/lxcfs-4-0-1-lts-has-been-released/7130) releases. Some of the highlights include:
 
    - Fix memory virtualization issues (swap reporting)
@@ -24,11 +24,11 @@ content: |-
    - tests: Handle different lib paths
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.2.tar.gz)
    - GPG signature: [lxcfs-4.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.2.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.3.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.3.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.3 LTS has been released
 date: 2020/04/17 20:04
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-3-lts-has-been-released/7470
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.3!
 
   This is the third bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   This release fixes a number of issues that were reported shortly following the [original 4.0.0](https://discuss.linuxcontainers.org/t/lxcfs-4-0-lts-has-been-released/7031), [4.0.1](https://discuss.linuxcontainers.org/t/lxcfs-4-0-1-lts-has-been-released/7130) and [4.0.2](https://discuss.linuxcontainers.org/t/lxcfs-4-0-2-lts-has-been-released/7327) releases. Some of the highlights include:
 
    - Fix some issues detected by Coverity Scan
@@ -38,11 +38,11 @@ content: |-
 
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.3.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.3.tar.gz)
    - GPG signature: [lxcfs-4.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.3.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.4.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.4.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.4 LTS has been released
 date: 2020/06/18 20:06
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-4-lts-has-been-released/8212
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.4!
 
   This is the fourth bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Fix internal cache (big performance improvement)
@@ -67,11 +67,11 @@ content: |-
    - proc_cpuview: cleanup cpuview_init_head()
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.4.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.4.tar.gz)
    - GPG signature: [lxcfs-4.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.4.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.5.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.5.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.5 LTS has been released
 date: 2020/08/03 22:08
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-5-lts-has-been-released/8602
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.5!
 
   This is the fifth bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Fix bad swap value on hosts without memsw enabled
@@ -27,11 +27,11 @@ content: |-
    - fix type mismatch
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.5.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.5.tar.gz)
    - GPG signature: [lxcfs-4.0.5.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.5.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.6.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.6.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.6 LTS has been released
 date: 2020/10/19 22:10
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-6-lts-has-been-released/9236
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.6!
 
   This is the sixth bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Add support for fuse3
@@ -26,11 +26,11 @@ content: |-
    - diskstats: support new fields in 4.18+ kernels
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.6.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.6.tar.gz)
    - GPG signature: [lxcfs-4.0.6.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.6.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.7.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.7.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.7 LTS has been released
 date: 2021/01/08 22:01
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-7-lts-has-been-released/9893
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.6!
 
   This is the seventh bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Consistent swap behavior (documented in README)
@@ -26,11 +26,11 @@ content: |-
    - docs: fix simple typo, throuh -> through
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.7.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.7.tar.gz)
    - GPG signature: [lxcfs-4.0.7.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.7.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.8.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.8.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.8 LTS has been released
 date: 2021/05/06 17:05
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-8-lts-has-been-released/10998
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.8!
 
   This is the eight bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Correct file size for proc files
@@ -20,11 +20,11 @@ content: |-
    - Switch to Github Actions
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.8.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.8.tar.gz)
    - GPG signature: [lxcfs-4.0.8.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.8.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-4.0.9.yaml
+++ b/content/lxcfs/news/lxcfs-4.0.9.yaml
@@ -2,12 +2,12 @@ title: LXCFS 4.0.9 LTS has been released
 date: 2021/07/17 02:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-4-0-9-lts-has-been-released/11617
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 4.0.9!
 
   This is the ninth bugfix release for LXCFS 4.0 which is supported until June 2025.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Improve libfuse2/libfuse3 handling
@@ -26,11 +26,11 @@ content: |-
    - lxcfs: handle libfuse2 vs libfuse3
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 4.0 branch is supported until June 2025.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-4.0.9.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.9.tar.gz)
    - GPG signature: [lxcfs-4.0.9.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-4.0.9.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-5.0.0.yaml
+++ b/content/lxcfs/news/lxcfs-5.0.0.yaml
@@ -2,35 +2,35 @@ title: LXCFS 5.0 LTS has been released
 date: 2022/03/10 23:03
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-lts-has-been-released/13535
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 5.0.0!
 
   This is the result of two years of work since the LXCFS 4.0.0 release and is the fourth LTS release for the LXCFS project. This release will be supported until June 2027.
 
-  ### Major changes
-  #### Switch to meson
+  # Major changes
+  ## Switch to meson
   With this release of LXCFS, autotools is being replaced by `meson` as the build tooling. Compatibility `Makefile` targets are provided for `all`, `install` and `dist`.
 
   This is a change which is particularly relevant for packagers as it otherwise has no user visible impact.
 
-  #### CGroup2 support
+  ## CGroup2 support
   LXCFS 5.0 properly detects and handles cgroup2, using the cgroup2 hierarchy to fetch the resource consumption information for the container. It also automatically disables the `cgroup` directory feature when run on a cgroup2 system.
 
-  #### /proc/slabinfo support
+  ## /proc/slabinfo support
   The per-cgroup slab allocation is now used to provide a container view of `/proc/slabinfo`.
 
-  #### /sys/devices/system/cpu/ support
+  ## /sys/devices/system/cpu/ support
   In addition to the existing `/sys/devices/system/cpu/online` support, LXCFS will now virtualize the entire `/sys/devices/system/cpu` directory in order to hide CPUs which aren't available to the container.
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 5.0.0 will be supported until June 2027 and our current LTS release, LXCFS 4.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXCFS users to plan an upgrade to the 5.0 branch.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-5.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.0.tar.gz)
    - GPG signature: [lxcfs-5.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.0.tar.gz.asc)
 
-  ### Contributors
+  # Contributors
   The LXCFS 5.0.0 release was brought to you by a total of 21 contributors.

--- a/content/lxcfs/news/lxcfs-5.0.1.yaml
+++ b/content/lxcfs/news/lxcfs-5.0.1.yaml
@@ -2,12 +2,12 @@ title: LXCFS 5.0.1 LTS has been released
 date: 2022/07/26 23:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-1-lts-has-been-released/14709
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 5.0.1!
 
   This is the first bugfix release for LXCFS 5.0 which is supported until June 2027.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Various fixes related to the meson migration
@@ -52,11 +52,11 @@ content: |-
    - github: Validate target branch
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-5.0.1.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.1.tar.gz)
    - GPG signature: [lxcfs-5.0.1.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.1.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-5.0.2.yaml
+++ b/content/lxcfs/news/lxcfs-5.0.2.yaml
@@ -2,14 +2,14 @@ title: LXCFS 5.0.2 LTS has been released
 date: 2022/08/09 21:08
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-2-lts-has-been-released/14811
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 5.0.2!
 
   This is the second bugfix release for LXCFS 5.0 which is supported until June 2027.
 
   It fixes a serious crash in LXCFS 5.0.1 when used with FUSE3.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Fix crash during load/reload on FUSE3
@@ -20,11 +20,11 @@ content: |-
    - fix reinitialization with fuse3
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-5.0.2.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.2.tar.gz)
    - GPG signature: [lxcfs-5.0.2.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.2.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-5.0.3.yaml
+++ b/content/lxcfs/news/lxcfs-5.0.3.yaml
@@ -2,12 +2,12 @@ title: LXCFS 5.0.3 LTS has been released
 date: 2023/01/17 02:01
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-3-lts-has-been-released/16167
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 5.0.3!
 
   This is the third bugfix release for LXCFS 5.0 which is supported until June 2027.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Fixes VFS caching issues when run under FUSE3
@@ -39,11 +39,11 @@ content: |-
    - cpuview: fix ABBA deadlock in find_proc_stat_nod
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-5.0.3.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.3.tar.gz)
    - GPG signature: [lxcfs-5.0.3.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.3.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-5.0.4.yaml
+++ b/content/lxcfs/news/lxcfs-5.0.4.yaml
@@ -2,12 +2,12 @@ title: LXCFS 5.0.4 LTS has been released
 date: 2023/07/25 22:07
 origin: https://discuss.linuxcontainers.org/t/lxcfs-5-0-4-lts-has-been-released/17707
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 5.0.4!
 
   This is the fourth bugfix release for LXCFS 5.0 which is supported until June 2027.
 
-  ### Bugfixes
+  # Bugfixes
   Some of the highlights for this release are:
 
    - Fixed the output format of /proc/diskstats
@@ -26,11 +26,11 @@ content: |-
    - github: Update for main branch
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   The LXCFS 5.0 branch is supported until June 2027.
   Only bugfixes and securitiy issues get included into the stable bugfix releases, so it's always safe and recommended to keep up and run the latest bugfix release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-5.0.4.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.4.tar.gz)
    - GPG signature: [lxcfs-5.0.4.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-5.0.4.tar.gz.asc)

--- a/content/lxcfs/news/lxcfs-6-0-lts-has-been-released.yaml
+++ b/content/lxcfs/news/lxcfs-6-0-lts-has-been-released.yaml
@@ -2,24 +2,24 @@ title: LXCFS 6.0 LTS has been released
 date: 2024/04/01 04:04
 origin: https://discuss.linuxcontainers.org/t/lxcfs-6-0-lts-has-been-released/19546
 content: |-
-  ### Introduction
+  # Introduction
   The LXCFS team is pleased to announce the release of LXCFS 6.0 LTS!
 
   This is the result of two years of work since the LXCFS 5.0 release and is the fifth LTS release for the LXCFS project. This release will be supported until June 2029.
 
-  ### Highlights
-  #### New `--enable-cgroup option`
+  # Highlights
+  ## New `--enable-cgroup option`
   LXCFS can provide a virtual cgroupfs (v1) tree for use by containers.
   This feature was implemented prior to cgroup namespaces being implemented in the kernel and effectively allow providing a similar experience on kernels lacking that feature.
 
   As most supported Linux distributions now all feature a kernel supporting cgroup namespaces and most new distros have even switched away from cgroupv1, it didn't make sense to keep this feature enabled by default. As a result, it has now been moved behind a new startup argument, `--enable-cgroup`.
 
-  #### CPUs no longer masked in /sys/devices/system/cpu
+  ## CPUs no longer masked in /sys/devices/system/cpu
   LXCFS 5.0 shipped with logic to filter out entries in `/sys/devices/system/cpu` based on what CPUs were allowed in the caller's cpuset. This behavior doesn't actually reflect the behavior on normal systems where even offline CPUs still show up in `/sys/devices/system/cpu`.
 
   As a result, LXCFS 6.0 reversed that logic and is now only making sure to keep the list of online/offline CPUs up to date while the individual CPU directories all remain accessible.
 
-  ### Full changelog
+  # Full changelog
 
   [details="Changelog"]
    - lxcfs_fuse: ensure lxcfs_fuse_compat.h is included after including fuse header
@@ -107,22 +107,22 @@ content: |-
    - cgroup_utils: explicitly check for cgroup2 FDs in cgroup_walkup_to_root
   [/details]
 
-  ### Support and upgrade
+  # Support and upgrade
   LXCFS 6.0 will be supported until June 2029 and our current LTS release, LXCFS 5.0 will now switch to a slower maintenance pace, only getting critical bugfixes and security updates.
 
   We strongly recommend all LXCFS users to plan an upgrade to the 6.0 branch.
 
-  ### Future release cadence
+  # Future release cadence
   To make new LXCFS features more readily available to users, we have decided to start producing non-LTS releases again. The planned interval is every 6 months with LXCFS 6.1 planned for October.
 
   Those releases will not benefit from the LTS guarantees around stability, support and security maintenance and will only be supported until the next release comes out.
 
   Production users will likely want to remain on an LTS release.
 
-  ### Downloads
+  # Downloads
 
    - Main release tarball: [lxcfs-6.0.0.tar.gz](https://linuxcontainers.org/downloads/lxcfs/lxcfs-6.0.0.tar.gz)
    - GPG signature: [lxcfs-6.0.0.tar.gz.asc](https://linuxcontainers.org/downloads/lxcfs/lxcfs-6.0.0.tar.gz.asc)
 
-  ### Contributors
+  # Contributors
   The LXCFS 6.0 release was brought to you by a total of 25 contributors.


### PR DESCRIPTION
The header levels are not consistent across .yaml news files. This PR aligns them to the top (H1) level and gives a similar look to the Incus documentation.