### PR TITLE
t9n/fr: Invisible fixes

### DIFF
--- a/content/incus/announcement.fr.md
+++ b/content/incus/announcement.fr.md
@@ -24,6 +24,7 @@ Aleksa created the fork shortly after Canonical’s decision to take LXD away fr
 Mais en plus de tout cela, il a également été pendant longtemps le responsable du paquetage de LXD dans OpenSUSE.
 Aleksa a créé ce fork peu après la décision de Canonical de retirer LXD de Linux Containers, le nom Incus ayant été introduit immédiatement après la sortie de LXD 5.16. Ce fork a d’abord été conçu comme un projet personnel, mais il a depuis suscité beaucoup d’intérêt de la part de la communauté et d’anciens contributeurs de LXD.
 
+
 <!--
 After some discussion with Aleksa and a fair bit of encouragement from our community, we have made the decision to take Incus under the umbrella of Linux Containers and will commit to it the infrastructure which was previously made available to LXD.
 -->

--- a/content/incus/introduction.fr.md
+++ b/content/incus/introduction.fr.md
@@ -24,7 +24,7 @@ En utilisant Incus, vous pouvez gérer vos instances (conteneurs et VM) avec son
 
 <!--
 The Incus project [was created](/incus/announcement/) by Aleksa Sarai as a community driven alternative to Canonical's LXD.
-Today, it's led and maintained by much of the same people that once created LXD.
+Today, it's led and maintained by many of the same people that once created LXD.
 -->
 Le projet Incus a [été créé](/incus/announcement/) par Aleksa Sarai comme une alternative à Canonical LXD gérée par la communauté.
 Aujourd’hui, il est dirigé et maintenu par bon nombre des personnes qui ont créé LXD.
@@ -123,6 +123,7 @@ Configurabilité
   * [Gestion du réseau](/incus/docs/main/explanation/networks/) (création de bridges, de tunnels entre hôtes…)
   * [Contrôle avancé des ressources](/incus/docs/main/reference/instance_options/#resource-limits) (gestion des processeurs, de la mémoire, des E/S du réseau et des périphériques, de l’utilisation des disques et des ressources du noyau)
   * [Passthrough de périphériques](/incus/docs/main/reference/devices/) (USB, GPU, périphériques en mode caractère ou bloc, cartes réseau, disques et chemins d’accès)
+
 
 <!--
 # Availability

--- a/content/incus/news.fr.md
+++ b/content/incus/news.fr.md
@@ -1,1 +1,4 @@
+<!--
+# News
+-->
 # Actualités


### PR DESCRIPTION
This commit fixes content/incus/news.fr.md to contain the last english source text and adds several line breaks and comments so that the diffs between content/*.md and content/*.fr.md only show additions.