### PR TITLE
content: Remove External resources sections

### DIFF
--- a/content/STRUCTURE.de.json
+++ b/content/STRUCTURE.de.json
@@ -138,9 +138,6 @@
      "meta": {"dir": "/downloads/lxc",
               "input": "lxc/downloads.md"}},
 
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "External resources"]},
-
     {"path": "/lxc/articles/",
      "title": "LXC - Articles",
      "menu": ["LXC", "Articles"],
@@ -226,9 +223,6 @@
      "meta": {"dir": "/downloads/lxcfs",
               "input": "lxcfs/downloads.md"}},
 
-    {"path": "/lxcfs/external-resources/",
-     "menu": ["LXCFS", "External resources"]},
-
     {"path": "/lxcfs/forum/",
      "menu": ["LXCFS", "Forum"],
      "generator": "link",
@@ -293,9 +287,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/distrobuilder",
               "input": "distrobuilder/downloads.de.md"}},
-
-    {"path": "/distrobuilder/external-resources/",
-     "menu": ["distrobuilder", "External resources"]},
 
     {"path": "/distrobuilder/forum/",
      "menu": ["distrobuilder", "Forum"],
@@ -373,9 +364,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/cgmanager",
               "input": "cgmanager/downloads.de.md"}},
-
-    {"path": "/cgmanager/external-resources/",
-     "menu": ["CGManager", "External resources"]},
 
     {"path": "/cgmanager/articles/",
      "title": "CGManager - Articles",

--- a/content/STRUCTURE.fr.json
+++ b/content/STRUCTURE.fr.json
@@ -138,9 +138,6 @@
      "meta": {"dir": "/downloads/lxc",
               "input": "lxc/downloads.md"}},
 
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "External resources"]},
-
     {"path": "/lxc/articles/",
      "title": "LXC - Articles",
      "menu": ["LXC", "Articles"],
@@ -226,9 +223,6 @@
      "meta": {"dir": "/downloads/lxcfs",
               "input": "lxcfs/downloads.md"}},
 
-    {"path": "/lxcfs/external-resources/",
-     "menu": ["LXCFS", "External resources"]},
-
     {"path": "/lxcfs/forum/",
      "menu": ["LXCFS", "Forum"],
      "generator": "link",
@@ -293,9 +287,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/distrobuilder",
               "input": "distrobuilder/downloads.md"}},
-
-    {"path": "/distrobuilder/external-resources/",
-     "menu": ["distrobuilder", "External resources"]},
 
     {"path": "/distrobuilder/forum/",
      "menu": ["distrobuilder", "Forum"],
@@ -373,9 +364,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/cgmanager",
               "input": "cgmanager/downloads.md"}},
-
-    {"path": "/cgmanager/external-resources/",
-     "menu": ["CGManager", "External resources"]},
 
     {"path": "/cgmanager/articles/",
      "title": "CGManager - Articles",

--- a/content/STRUCTURE.id.json
+++ b/content/STRUCTURE.id.json
@@ -138,9 +138,6 @@
      "meta": {"dir": "/downloads/lxc",
               "input": "lxc/downloads.id.md"}},
 
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "External resources"]},
-
     {"path": "/lxc/articles/",
      "title": "LXC - Artikel",
      "menu": ["LXC", "Artikel"],
@@ -226,9 +223,6 @@
      "meta": {"dir": "/downloads/lxcfs",
               "input": "lxcfs/downloads.md"}},
 
-    {"path": "/lxcfs/external-resources/",
-     "menu": ["LXCFS", "External resources"]},
-
     {"path": "/lxcfs/forum/",
      "menu": ["LXCFS", "Forum"],
      "generator": "link",
@@ -293,9 +287,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/distrobuilder",
               "input": "distrobuilder/downloads.md"}},
-
-    {"path": "/distrobuilder/external-resources/",
-     "menu": ["distrobuilder", "External resources"]},
 
     {"path": "/distrobuilder/forum/",
      "menu": ["distrobuilder", "Forum"],
@@ -373,9 +364,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/cgmanager",
               "input": "cgmanager/downloads.md"}},
-
-    {"path": "/cgmanager/external-resources/",
-     "menu": ["CGManager", "External resources"]},
 
     {"path": "/cgmanager/articles/",
      "title": "CGManager - Articles",

--- a/content/STRUCTURE.ja.json
+++ b/content/STRUCTURE.ja.json
@@ -137,9 +137,6 @@
      "meta": {"dir": "/downloads/lxc",
               "input": "lxc/downloads.ja.md"}},
 
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "外部リソース"]},
-
     {"path": "/lxc/articles/",
      "title": "LXC - 記事",
      "menu": ["LXC", "記事"],
@@ -222,9 +219,6 @@
      "meta": {"dir": "/downloads/lxcfs",
               "input": "lxcfs/downloads.ja.md"}},
 
-    {"path": "/lxcfs/external-resources/",
-     "menu": ["LXCFS", "外部リソース"]},
-
     {"path": "/lxcfs/forum/",
      "menu": ["LXCFS", "フォーラム"],
      "generator": "link",
@@ -289,9 +283,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/distrobuilder",
               "input": "distrobuilder/downloads.ja.md"}},
-
-    {"path": "/distrobuilder/external-resources/",
-     "menu": ["distrobuilder", "外部リソース"]},
 
     {"path": "/distrobuilder/forum/",
      "menu": ["distrobuilder", "フォーラム"],
@@ -362,9 +353,6 @@
      "menu": ["CGManager", "ダウンロード"],
      "meta": {"dir": "/downloads/cgmanager",
               "input": "cgmanager/downloads.ja.md"}},
-
-    {"path": "/cgmanager/external-resources/",
-     "menu": ["CGManager", "外部リソース"]},
 
     {"path": "/cgmanager/articles/",
      "title": "CGManager - 記事",

--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -138,9 +138,6 @@
      "meta": {"dir": "/downloads/lxc",
               "input": "lxc/downloads.md"}},
 
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "External resources"]},
-
     {"path": "/lxc/articles/",
      "title": "LXC - Articles",
      "menu": ["LXC", "Articles"],
@@ -226,9 +223,6 @@
      "meta": {"dir": "/downloads/lxcfs",
               "input": "lxcfs/downloads.md"}},
 
-    {"path": "/lxcfs/external-resources/",
-     "menu": ["LXCFS", "External resources"]},
-
     {"path": "/lxcfs/forum/",
      "menu": ["LXCFS", "Forum"],
      "generator": "link",
@@ -293,9 +287,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/distrobuilder",
               "input": "distrobuilder/downloads.md"}},
-
-    {"path": "/distrobuilder/external-resources/",
-     "menu": ["distrobuilder", "External resources"]},
 
     {"path": "/distrobuilder/forum/",
      "menu": ["distrobuilder", "Forum"],
@@ -373,9 +364,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/cgmanager",
               "input": "cgmanager/downloads.md"}},
-
-    {"path": "/cgmanager/external-resources/",
-     "menu": ["CGManager", "External resources"]},
 
     {"path": "/cgmanager/articles/",
      "title": "CGManager - Articles",

--- a/content/STRUCTURE.zh-cn.json
+++ b/content/STRUCTURE.zh-cn.json
@@ -141,9 +141,6 @@
      "meta": {"dir": "/downloads/lxc",
               "input": "lxc/downloads.md"}},
 
-    {"path": "/lxc/external-resources/",
-     "menu": ["LXC", "外部资源"]},
-
     {"path": "/lxc/articles/",
      "title": "LXC - 文章",
      "menu": ["LXC", "文章"],
@@ -227,9 +224,6 @@
      "meta": {"dir": "/downloads/lxcfs",
               "input": "lxcfs/downloads.md"}},
 
-    {"path": "/lxcfs/external-resources/",
-     "menu": ["LXCFS", "外部资源"]},
-
     {"path": "/lxcfs/forum/",
      "menu": ["LXCFS", "论坛"],
      "generator": "link",
@@ -294,9 +288,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/distrobuilder",
               "input": "distrobuilder/downloads.md"}},
-
-    {"path": "/distrobuilder/external-resources/",
-     "menu": ["distrobuilder", "外部资源"]},
 
     {"path": "/distrobuilder/forum/",
      "menu": ["distrobuilder", "论坛"],
@@ -374,9 +365,6 @@
      "generator": "downloads",
      "meta": {"dir": "/downloads/cgmanager",
               "input": "cgmanager/downloads.md"}},
-
-    {"path": "/cgmanager/external-resources/",
-     "menu": ["CGManager", "外部资源"]},
 
     {"path": "/cgmanager/articles/",
      "title": "CGManager - 文章",


### PR DESCRIPTION
The “External resources” sections point to nothing. This PR removes them.