### PR TITLE
Add RSS news feeds for all projects

### DIFF
--- a/content/STRUCTURE.json
+++ b/content/STRUCTURE.json
@@ -43,6 +43,13 @@
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
+    {"path": "/incus/news.rss",
+     "title": "Incus - News RSS Feed",
+     "generator": "rss",
+     "meta": {"dir": "/content/incus/news/",
+              "description": "Latest Incus news and release announcements",
+              "base_url": "https://linuxcontainers.org"}},
+
     {"path": "/incus/docs/",
      "menu": ["Incus", "Documentation"],
      "generator": "link",
@@ -109,6 +116,13 @@
               "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
+
+    {"path": "/lxc/news.rss",
+     "title": "LXC - News RSS Feed",
+     "generator": "rss",
+     "meta": {"dir": "/content/lxc/news/",
+              "description": "Latest LXC news and release announcements",
+              "base_url": "https://linuxcontainers.org"}},
 
     {"path": "/lxc/getting-started/",
      "title": "LXC - Getting started",
@@ -202,6 +216,13 @@
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
 
+    {"path": "/lxcfs/news.rss",
+     "title": "LXCFS - News RSS Feed",
+     "generator": "rss",
+     "meta": {"dir": "/content/lxcfs/news/",
+              "description": "Latest LXCFS news and release announcements",
+              "base_url": "https://linuxcontainers.org"}},
+
     {"path": "/lxcfs/getting-started/",
      "title": "LXCFS - Getting started",
      "menu": ["LXCFS", "Getting started"],
@@ -270,6 +291,13 @@
               "toc_depth": "2-3",
               "str_older": "Older news",
               "str_back": "Back to the news overview"}},
+
+    {"path": "/distrobuilder/news.rss",
+     "title": "distrobuilder - News RSS Feed",
+     "generator": "rss",
+     "meta": {"dir": "/content/distrobuilder/news/",
+              "description": "Latest distrobuilder news and release announcements",
+              "base_url": "https://linuxcontainers.org"}},
 
     {"path": "/distrobuilder/documentation",
      "menu": ["distrobuilder", "Documentation"],

--- a/generate
+++ b/generate
@@ -285,6 +285,83 @@ def gen_page(entry, override, prefix, **variables):
         # Skip the virtual entries (external links, splitters)
         return
 
+    # Handle RSS generator early (it needs a different output path)
+    if item["generator"] == "rss":
+        # Generate RSS feed
+        articles = []
+        news_path = item["meta"]["dir"].lstrip("/")
+
+        # Load all articles
+        for entry in os.listdir(news_path):
+            with open(os.path.join(news_path, entry), "r") as fd:
+                article = yaml.safe_load(fd)
+                if not article:
+                    continue
+                articles.append(article)
+
+        # Sort articles by date (newest first)
+        articles = sorted(articles, key=lambda article: article["date"], reverse=True)
+
+        # Limit to most recent articles (e.g., last 20)
+        articles = articles[:20]
+
+        # Generate RSS XML content
+        rss_items = []
+        for article in articles:
+            date = datetime.datetime.strptime(article["date"], "%Y/%m/%d %H:%M")
+
+            # Convert to RFC 2822 format for RSS
+            rss_date = date.strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+            # Clean up content for RSS (convert markdown to HTML if needed)
+            description = article.get("content", "")
+
+            # Create a simple HTML description
+            description = description.replace("\n", "<br/>")
+
+            # Build the RSS item
+            rss_item = f"""    <item>
+      <title>{article["title"]}</title>
+      <description><![CDATA[{description}]]></description>
+      <pubDate>{rss_date}</pubDate>"""
+
+            if "origin" in article:
+                rss_item += f"""
+      <link>{article["origin"]}</link>
+      <guid>{article["origin"]}</guid>"""
+
+            rss_item += "\n    </item>"
+            rss_items.append(rss_item)
+
+        # Build the complete RSS feed
+        feed_title = item.get("title", "News Feed")
+        feed_description = item["meta"].get("description", "Latest news and updates")
+        base_url = item["meta"].get("base_url", "https://linuxcontainers.org")
+        feed_link = f"{base_url}{item['path'].replace('.rss', '/')}"
+
+        current_date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+        content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>{feed_title}</title>
+    <description>{feed_description}</description>
+    <link>{feed_link}</link>
+    <lastBuildDate>{current_date}</lastBuildDate>
+    <generator>linuxcontainers.org static generator</generator>
+{''.join(rss_items)}
+  </channel>
+</rss>"""
+
+        # Write RSS content directly (no template needed)
+        output_path = "%s%s" % (TARGET_PATH, item["path"])
+        if not os.path.exists(os.path.dirname(output_path)):
+            os.makedirs(os.path.dirname(output_path))
+
+        with open(output_path, "w+") as fd:
+            fd.write(content)
+        return
+
     # Generate the target path and create any missing directory
     output_path = "%s%s/index.html" % (TARGET_PATH, item["path"])
     if not os.path.exists(os.path.dirname(output_path)):
@@ -439,7 +516,7 @@ def gen_page(entry, override, prefix, **variables):
                         page_title="%s - %s" % (item["title"], entry),
                         page_menu=item.get("menu", []) + [entry],
                         content=content,
-                        **variables
+                        **variables,
                     )
                 )
 
@@ -533,7 +610,7 @@ def gen_page(entry, override, prefix, **variables):
                             % (item["meta"]["str_back"], article_content),
                             item["meta"],
                         ),
-                        **variables
+                        **variables,
                     )
                 )
 
@@ -562,7 +639,7 @@ def gen_page(entry, override, prefix, **variables):
                 page_title=item["title"],
                 page_menu=item["menu"] if "menu" in item else None,
                 content=content,
-                **variables
+                **variables,
             )
         )
 

--- a/templates/common/base.tpl.html
+++ b/templates/common/base.tpl.html
@@ -32,6 +32,27 @@
   <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.1.0.min.css" />
   <link rel="stylesheet" href="/static/css/local.css" />
   <link rel="stylesheet" href="/static/css/pygments.css" />
+
+  <!-- RSS feed discovery -->
+  {% if page_path.startswith('/incus/') %}
+  <link rel="alternate" type="application/rss+xml" title="Incus News" href="/incus/news.rss">
+  {% endif %}
+  {% if page_path.startswith('/lxc/') %}
+  <link rel="alternate" type="application/rss+xml" title="LXC News" href="/lxc/news.rss">
+  {% endif %}
+  {% if page_path.startswith('/lxcfs/') %}
+  <link rel="alternate" type="application/rss+xml" title="LXCFS News" href="/lxcfs/news.rss">
+  {% endif %}
+  {% if page_path.startswith('/distrobuilder/') %}
+  <link rel="alternate" type="application/rss+xml" title="distrobuilder News" href="/distrobuilder/news.rss">
+  {% endif %}
+  {% if page_path == '/' %}
+  <!-- Homepage includes all project RSS feeds -->
+  <link rel="alternate" type="application/rss+xml" title="Incus News" href="/incus/news.rss">
+  <link rel="alternate" type="application/rss+xml" title="LXC News" href="/lxc/news.rss">
+  <link rel="alternate" type="application/rss+xml" title="LXCFS News" href="/lxcfs/news.rss">
+  <link rel="alternate" type="application/rss+xml" title="distrobuilder News" href="/distrobuilder/news.rss">
+  {% endif %}
   {% endblock %}
 </head>
 


### PR DESCRIPTION
Hi, relating to #212 , I'd like to propose adding RSS feeds to this site

Changes:

- Add RSS feed endpoints for Incus, LXC, LXCFS, and distrobuilder
- Implement RSS generator in the build system to create XML feeds
- Add RSS feed discovery meta tags in HTML head
- Generate feeds with latest 20 articles, proper RFC 2822 dates
- Include project-specific RSS links on relevant pages and homepage

I've successfully tested my changes locally.  Feedback or direct edits are welcome